### PR TITLE
Solve ruff and pylint warnings

### DIFF
--- a/custom_components/weishaupt_modbus/__init__.py
+++ b/custom_components/weishaupt_modbus/__init__.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-# from pathlib import Path
+from pathlib import Path
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -61,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
 
     for device in DEVICELISTS:
         for item in device:
-            itemlist.append(item)
+            itemlist.append(item)  # noqa: PERF402
 
     coordinator = MyCoordinator(
         hass=hass, my_api=mbapi, api_items=itemlist, p_config_entry=entry
@@ -244,9 +244,8 @@ def create_string_json() -> None:
 
     # load strings.json into string
     # replaced Path.open by open
-    with open(
-        file="config/custom_components/weishaupt_modbus/strings.json",
-        encoding="utf-8",
+    with Path("config/custom_components/weishaupt_modbus/strings.json").open(
+        encoding="utf-8"
     ) as file:
         data = file.read()
     # create dict from json
@@ -255,8 +254,7 @@ def create_string_json() -> None:
     data_dict["entity"] = myEntity
     # write whole json to file again
     # replaced Path.open by open
-    with open(
-        file="config/custom_components/weishaupt_modbus/strings.json",
+    with Path("config/custom_components/weishaupt_modbus/strings.json").open(
         mode="w",
         encoding="utf-8",
     ) as file:

--- a/custom_components/weishaupt_modbus/config_flow.py
+++ b/custom_components/weishaupt_modbus/config_flow.py
@@ -1,16 +1,19 @@
 """Config flow."""
 
 from typing import Any
+
 from aiofiles.os import scandir
 import voluptuous as vol
+
 from homeassistant import config_entries, exceptions
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+
 from .const import CONF, CONST
 
 
 async def build_kennfeld_list(hass: HomeAssistant):
-    """Browse integration directory for kennfeld files."""
+    """Browse integration directory for heat pump operation map ("kennfeld") files."""
     kennfelder = []
     filelist = []
 
@@ -64,7 +67,7 @@ async def validate_input(data: dict) -> dict[str, Any]:
     return {"title": data["host"]}
 
 
-class ConfigFlow(config_entries.ConfigFlow, domain=CONST.DOMAIN):  # pylint: disable=W0223
+class ConfigFlow(config_entries.ConfigFlow, domain=CONST.DOMAIN):  # pylint: disable=abstract-method
     """Class config flow."""
 
     VERSION = 5

--- a/custom_components/weishaupt_modbus/const.py
+++ b/custom_components/weishaupt_modbus/const.py
@@ -5,8 +5,8 @@ from datetime import timedelta
 
 from homeassistant.const import (
     CONF_HOST,
-    CONF_PORT,
     CONF_PASSWORD,
+    CONF_PORT,
     CONF_PREFIX,
     CONF_USERNAME,
 )
@@ -14,7 +14,7 @@ from homeassistant.const import (
 
 @dataclass(frozen=True)
 class ConfConstants:
-    """Constants used for configurastion"""
+    """Constants used for configuration."""
 
     HOST = CONF_HOST
     PORT = CONF_PORT

--- a/custom_components/weishaupt_modbus/coordinator.py
+++ b/custom_components/weishaupt_modbus/coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .configentry import MyConfigEntry
-from .const import CONST, TYPES, DEVICES, CONF
+from .const import CONF, CONST, DEVICES, TYPES
 from .items import ModbusItem
 from .modbusobject import ModbusAPI, ModbusObject
 from .webif_object import WebifConnection
@@ -79,7 +79,7 @@ class MyCoordinator(DataUpdateCoordinator):
         return modbus_item.state
 
     def get_value_from_item(self, translation_key: str) -> int:
-        """Read a value from another modbus item"""
+        """Read a value from another modbus item."""
         for _useless, item in enumerate(self._modbusitems):
             if item.translation_key == translation_key:
                 return item.state
@@ -100,13 +100,13 @@ class MyCoordinator(DataUpdateCoordinator):
         """Fetch all values from the modbus."""
         # if idx is not None:
         if idx is None:
-            # first run: Update all entitiies
+            # first run: Update all entities
             to_update = tuple(range(len(self._modbusitems)))
         elif len(idx) == 0:
-            # idx exists but is not yet filled up: Update all entitiys.
+            # idx exists but is not yet filled up: Update all entities.
             to_update = tuple(range(len(self._modbusitems)))
         else:
-            # idx exists and is filled up: Update only entitys requested by the coordinator.
+            # idx exists and is filled up: Update only entities requested by the coordinator.
             to_update = idx
 
         # await self._modbus_api.connect()
@@ -141,7 +141,7 @@ class MyCoordinator(DataUpdateCoordinator):
             # data retrieved from API.
             try:
                 # listening_idx = set(self.async_contexts())
-                return await self.fetch_data()  # !!!!!using listening_idx will result in some entities nevwer updated !!!!!
+                return await self.fetch_data()  # !!!!!using listening_idx will result in some entities never updated !!!!!
             except ModbusException:
                 log.warning("connection to the heatpump failed")
 

--- a/custom_components/weishaupt_modbus/entities.py
+++ b/custom_components/weishaupt_modbus/entities.py
@@ -1,4 +1,4 @@
-"""Entity classes used in this integration"""
+"""Entity classes used in this integration."""
 
 import logging
 
@@ -106,7 +106,7 @@ class MyEntity(Entity):
                 self._attr_icon = icon
 
     def set_min_max(self, onlydynamic: bool = False):
-        """sets min max to fixed or dynamic values"""
+        """Set min max to fixed or dynamic values."""
         if self._api_item.params is None:
             return
 
@@ -137,7 +137,7 @@ class MyEntity(Entity):
             self._attr_native_max_value = self._api_item.params.get("max", 999999)
 
     def translate_val(self, val) -> float:
-        """Translate modbus value into sensful format."""
+        """Translate modbus value into senseful format."""
         if self._api_item.format == FORMATS.STATUS:
             return self._api_item.get_translation_key_from_number(val)
 
@@ -252,55 +252,55 @@ class MyCalcSensorEntity(MySensorEntity):
         if self._api_item.params is None:
             return None
         if "val_1" in self._calculation_source:
-            val_1 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa F841 pylint: disable=W0612
+            val_1 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa: F841 pylint: disable=unused-variable
                 self._api_item.params.get("val_1", 1)
             )
         if "val_2" in self._calculation_source:
-            val_2 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa F841 pylint: disable=W0612
+            val_2 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa: F841 pylint: disable=unused-variable
                 self._api_item.params.get("val_2", 1)
             )
         if "val_3" in self._calculation_source:
-            val_3 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa F841 pylint: disable=W0612
+            val_3 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa: F841 pylint: disable=unused-variable
                 self._api_item.params.get("val_3", 1)
             )
         if "val_4" in self._calculation_source:
-            val_4 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa F841 pylint: disable=W0612
+            val_4 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa: F841 pylint: disable=unused-variable
                 self._api_item.params.get("val_4", 1)
             )
         if "val_5" in self._calculation_source:
-            val_5 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa F841 pylint: disable=W0612
+            val_5 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa: F841 pylint: disable=unused-variable
                 self._api_item.params.get("val_5", 1)
             )
         if "val_6" in self._calculation_source:
-            val_6 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa F841 pylint: disable=W0612
+            val_6 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa: F841 pylint: disable=unused-variable
                 self._api_item.params.get("val_6", 1)
             )
         if "val_7" in self._calculation_source:
-            val_7 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa F841 pylint: disable=W0612
+            val_7 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa: F841 pylint: disable=unused-variable
                 self._api_item.params.get("val_7", 1)
             )
         if "val_8" in self._calculation_source:
-            val_8 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa F841 pylint: disable=W0612
+            val_8 = self._config_entry.runtime_data.coordinator.get_value_from_item(  # noqa: F841 pylint: disable=unused-variable
                 self._api_item.params.get("val_8", 1)
             )
         if "power" in self._calculation_source:
-            power = self._config_entry.runtime_data.powermap  # noqa F841 pylint: disable=W0612
+            power = self._config_entry.runtime_data.powermap  # noqa: F841 pylint: disable=unused-variable
 
         try:
-            val_0 = val / self._divider  # noqa F841 pylint: disable=W0612
-            y = eval(self._calculation)  # pylint: disable=W0123
+            val_0 = val / self._divider  # noqa: F841 pylint: disable=unused-variable
+            y = eval(self._calculation)  # pylint: disable=eval-used  # noqa: S307
         except ZeroDivisionError:
             return None
         except NameError:
             log.warning("Variable not defined %s", self._calculation_source)
             return None
         except TypeError:
-            log.warning("No valid calulation string")
+            log.warning("No valid calculation string")
             return None
         return round(y, self._attr_suggested_display_precision)
 
 
-class MyNumberEntity(CoordinatorEntity, NumberEntity, MyEntity):  # pylint: disable=W0223
+class MyNumberEntity(CoordinatorEntity, NumberEntity, MyEntity):  # pylint: disable=abstract-method
     """Represent a Number Entity.
 
     Class that represents a sensor entity derived from Sensorentity
@@ -337,7 +337,7 @@ class MyNumberEntity(CoordinatorEntity, NumberEntity, MyEntity):  # pylint: disa
         return MyEntity.my_device_info(self)
 
 
-class MySelectEntity(CoordinatorEntity, SelectEntity, MyEntity):  # pylint: disable=W0223
+class MySelectEntity(CoordinatorEntity, SelectEntity, MyEntity):  # pylint: disable=abstract-method
     """Class that represents a sensor entity.
 
     Class that represents a sensor entity derived from Sensorentity
@@ -351,7 +351,7 @@ class MySelectEntity(CoordinatorEntity, SelectEntity, MyEntity):  # pylint: disa
         coordinator: MyCoordinator,
         idx,
     ) -> None:
-        """Initialze MySelectEntity."""
+        """Initialize MySelectEntity."""
         super().__init__(coordinator, context=idx)
         self._idx = idx
         MyEntity.__init__(self, config_entry, modbus_item, coordinator.modbus_api)
@@ -360,7 +360,7 @@ class MySelectEntity(CoordinatorEntity, SelectEntity, MyEntity):  # pylint: disa
         ]
         # option list build from the status list of the ModbusItem
         self.options = []
-        for _useless, item in enumerate(self._api_item._resultlist):
+        for _useless, item in enumerate(self._api_item._resultlist):  # noqa: SLF001
             self.options.append(item.translation_key)
         self._attr_current_option = "FEHLER"
 
@@ -445,7 +445,7 @@ class MyWebifSensorEntity(CoordinatorEntity, SensorEntity, MyEntity):
         except KeyError:
             log.warning("Key Error: %s", self._api_item.name)
 
-    async def async_turn_on(self, **kwargs):  # pylint: disable=W0613
+    async def async_turn_on(self, **kwargs):  # pylint: disable=unused-argument
         """Turn the light on.
 
         Example method how to request data updates.

--- a/custom_components/weishaupt_modbus/entity_helpers.py
+++ b/custom_components/weishaupt_modbus/entity_helpers.py
@@ -1,19 +1,20 @@
-"""Build entitiy List and Update Coordinator."""
+"""Build entity List and Update Coordinator."""
 
 import logging
+
 from .configentry import MyConfigEntry
-from .items import ModbusItem, WebItem
-from .modbusobject import ModbusObject
 from .const import TYPES
 from .coordinator import MyCoordinator, check_configured
-from .entities import MySensorEntity, MyCalcSensorEntity, MyNumberEntity, MySelectEntity
+from .entities import MyCalcSensorEntity, MyNumberEntity, MySelectEntity, MySensorEntity
+from .items import ModbusItem, WebItem
+from .modbusobject import ModbusObject
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
 
 
 async def check_available(modbus_item: ModbusItem, config_entry: MyConfigEntry) -> bool:
-    """function checks if item is valid and available
+    """Check if item is valid and available.
 
     :param config_entry: HASS config entry
     :type config_entry: MyConfigEntry
@@ -26,9 +27,7 @@ async def check_available(modbus_item: ModbusItem, config_entry: MyConfigEntry) 
     _modbus_api = config_entry.runtime_data.modbus_api
     mbo = ModbusObject(_modbus_api, modbus_item)
     _useless = await mbo.value
-    if modbus_item.is_invalid is False:
-        return True
-    return False
+    return modbus_item.is_invalid is False
 
 
 async def build_entity_list(

--- a/custom_components/weishaupt_modbus/hpconst.py
+++ b/custom_components/weishaupt_modbus/hpconst.py
@@ -1,14 +1,15 @@
 """Heatpump constants."""
 
 import copy
+
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
-    UnitOfTime,
+    PERCENTAGE,
     UnitOfEnergy,
     UnitOfPower,
     UnitOfTemperature,
+    UnitOfTime,
     UnitOfVolumeFlowRate,
-    PERCENTAGE,
 )
 
 from .const import DEVICES, FORMATS, TYPES
@@ -30,8 +31,8 @@ reverse_device_list: dict[str, str] = {
 }
 
 ################################################################################
-# Listen mit Fehlermeldungen, Warnmeldungen und Statustexte
-# Beschreibungstext ist ebenfalls möglich
+# Lists with error messages, warning messages, and status texts
+# Description text is also possible
 # class StatusItem(): def __init__(self, number, text, description = None):
 ################################################################################
 
@@ -171,7 +172,7 @@ SYS_FEHLER: list[StatusItem] = [
     StatusItem(number=182,text="Stromaufnahme zu hoch", translation_key="sys_fehler_182"),
     StatusItem(number=183,text="Stromaufnahme zu hoch", translation_key="sys_fehler_183"),
     StatusItem(number=184,text="Spannung zu hoch", translation_key="sys_fehler_184"),
-]  # noqa: E501
+]
 
 # fmt: on
 
@@ -930,14 +931,14 @@ IO_STATUS: list[StatusItem] = [
 ##############################################################################################################################
 # A parameter list that can contain the following elements:
 # all of the entries are optional on general
-# "min": The lowest allowed value of the entity that can be set by the user if read/write. 
+# "min": The lowest allowed value of the entity that can be set by the user if read/write.
 #        Not needed for SENSOR, SELECT, SENSOR_CALC
 # "dynamic_min": The translation key of another entity of this integration. The content of this entity will be used as min val
-# "max": The highest allowed value of the entity that can be set by the user if read/write. 
+# "max": The highest allowed value of the entity that can be set by the user if read/write.
 #        Not needed for SENSOR, SELECT, SENSOR_CALC
 # "dynamic_max": The translation key of another entity of this integration. The content of this entity will be used as max val
 # "step": the step when entity is r/w, values can only be set according this step
-# "divider": On modbus, values usually are coded as int. To get the real float number, 
+# "divider": On modbus, values usually are coded as int. To get the real float number,
 #            the modbus value has to be divided by this value
 # "deviceclass": one of the SensorDeviceClass entries of HomeAssistant definition
 # "precision": number of digits after the decimal point
@@ -1203,10 +1204,10 @@ PARAMS_TIME_H: dict = {"icon": "mdi:clock-time-eight", "unit": UnitOfTime.HOURS}
 #              SELECT: A select entity
 #              NUMBER: A number entity. The value of this entity can be changed by the user interface
 #              NUMBER_RO: In principle, this is also a number entity that ir writable. But to avoid damages at the heatpump
-#                         we decided to make this entity read only. 
+#                         we decided to make this entity read only.
 # device: The devise this entity is assigned to. Devices are used here to group the entities in a meaningful way
 # params: Parameters to control the behavior of the entity, see description of the params lists
-# translation_key: The identifier that points to the right translation key. Therefore, the files strings.json and the 
+# translation_key: The identifier that points to the right translation key. Therefore, the files strings.json and the
 #                  language specific files in the subfolder "translations" have to be up-to-date
 ##############################################################################################################################
 
@@ -1246,7 +1247,7 @@ MODBUS_WP_ITEMS: list[ModbusItem] = [
     ModbusItem( address=43108, name="Sollwert Volumenstrom Heizen", mformat=FORMATS.NUMBER, mtype=TYPES.NUMBER_RO, device=DEVICES.WP, params=PARAMS_FLOWRATE, translation_key="soll_volumenstrom_heizen"),
     ModbusItem( address=43109, name="Sollwert Volumenstrom Kühlen", mformat=FORMATS.NUMBER, mtype=TYPES.NUMBER_RO,  device=DEVICES.WP, params=PARAMS_FLOWRATE, translation_key="soll_volumenstrom_kuehlen"),
     ModbusItem( address=43110, name="Sollwert Volumenstrom Warmwasser", mformat=FORMATS.NUMBER, mtype=TYPES.NUMBER_RO, device=DEVICES.WP, params=PARAMS_FLOWRATE, translation_key="soll_volumenstrom_ww"),
-] # noqa: E501
+]
 
 MODBUS_HZ_ITEMS = [
     ModbusItem( address=31101, name="Raumsolltemperatur", mformat=FORMATS.TEMPERATUR, mtype=TYPES.SENSOR, device=DEVICES.HZ, params=PARAMS_ROOMTEMP, translation_key="raum_soll_temp"),
@@ -1267,7 +1268,7 @@ MODBUS_HZ_ITEMS = [
     ModbusItem( address=41110, name="Heizen Konstanttemperatur", mformat=FORMATS.TEMPERATUR, mtype=TYPES.NUMBER_RO, device=DEVICES.HZ, params=PARAMS_ROOMTEMP, translation_key="heiz_konstanttemp"),
     ModbusItem( address=41111, name="Heizen Konstanttemp Absenk", mformat=FORMATS.TEMPERATUR, mtype=TYPES.NUMBER_RO, device=DEVICES.HZ, params=PARAMS_ROOMTEMP, translation_key="heiz_konstanttemp_absenk"),
     ModbusItem( address=41112, name="Kühlen Konstanttemperatur", mformat=FORMATS.TEMPERATUR, mtype=TYPES.NUMBER_RO, device=DEVICES.HZ, params=PARAMS_ROOMTEMP, translation_key="kuehl_konstanttemp"),
-] # noqa: E501
+]
 
 # buils other Heizkreis Itemlists
 MODBUS_HZ2_ITEMS: list = []
@@ -1277,7 +1278,7 @@ for item in MODBUS_HZ_ITEMS:
     mbi.name = item.name + "2"
     mbi.translation_key = item.translation_key + "2"
     mbi.device = DEVICES.HZ2
-    MODBUS_HZ2_ITEMS.append(mbi)  # noqa: PERF401
+    MODBUS_HZ2_ITEMS.append(mbi)
 
 # buils other Heizkreis Itemlists
 MODBUS_HZ3_ITEMS: list = []
@@ -1287,7 +1288,7 @@ for item in MODBUS_HZ_ITEMS:
     mbi.name = item.name + "3"
     mbi.translation_key = item.translation_key + "3"
     mbi.device = DEVICES.HZ3
-    MODBUS_HZ3_ITEMS.append(mbi)  # noqa: PERF401
+    MODBUS_HZ3_ITEMS.append(mbi)
 
 # buils other Heizkreis Itemlists
 MODBUS_HZ4_ITEMS: list = []
@@ -1297,7 +1298,7 @@ for item in MODBUS_HZ_ITEMS:
     mbi.name = item.name + "4"
     mbi.translation_key = item.translation_key + "4"
     mbi.device = DEVICES.HZ4
-    MODBUS_HZ4_ITEMS.append(mbi)  # noqa: PERF401
+    MODBUS_HZ4_ITEMS.append(mbi)
 
 # buils other Heizkreis Itemlists
 MODBUS_HZ5_ITEMS: list = []
@@ -1307,7 +1308,7 @@ for item in MODBUS_HZ_ITEMS:
     mbi.name = item.name + "5"
     mbi.translation_key = item.translation_key + "5"
     mbi.device = DEVICES.HZ5
-    MODBUS_HZ5_ITEMS.append(mbi)  # noqa: PERF401
+    MODBUS_HZ5_ITEMS.append(mbi)
 
 MODBUS_WW_ITEMS: list[ModbusItem] = [
     ModbusItem( address=32101, name="Warmwassersolltemperatur", mformat=FORMATS.TEMPERATUR, mtype=TYPES.SENSOR, device=DEVICES.WW, params=PARAMS_WATERTEMP, translation_key="ww_soll_temp"),
@@ -1317,7 +1318,7 @@ MODBUS_WW_ITEMS: list[ModbusItem] = [
     ModbusItem( address=42103, name="Warmwasser Normal", mformat=FORMATS.TEMPERATUR, mtype=TYPES.NUMBER, device=DEVICES.WW, params=PARAMS_WATERTEMP_HIGH, translation_key="ww_normal"),
     ModbusItem( address=42104, name="Warmwasser Absenk", mformat=FORMATS.TEMPERATUR, mtype=TYPES.NUMBER, device=DEVICES.WW, params=PARAMS_WATERTEMP_LOW, translation_key="ww_absenk"),
     ModbusItem( address=42105, name="SG Ready Anhebung", mformat=FORMATS.TEMPERATUR, mtype=TYPES.NUMBER, device=DEVICES.WW, params=PARAMS_SGREADYTEMP, translation_key="sgr_anhebung"),
-] # noqa: E501
+]
 
 MODBUS_W2_ITEMS: list[ModbusItem] = [
     ModbusItem( address=34101, name="Status 2. WEZ", mformat=FORMATS.STATUS, mtype=TYPES.SENSOR, device=DEVICES.W2, resultlist=W2_STATUS, translation_key="status_2_wez"),
@@ -1337,7 +1338,7 @@ MODBUS_W2_ITEMS: list[ModbusItem] = [
     ModbusItem( address=44104, name="Grenztemperatur", mformat=FORMATS.TEMPERATUR, mtype=TYPES.NUMBER, device=DEVICES.W2, params=PARAMS_BIVALENZTEMP, translation_key="grenztemp"),
     ModbusItem( address=44105, name="Bivalenztemperatur", mformat=FORMATS.TEMPERATUR, mtype=TYPES.NUMBER, device=DEVICES.W2, params=PARAMS_BIVALENZTEMP, translation_key="bivalenztemp"),
     ModbusItem( address=44106, name="Bivalenztemperatur WW", mformat=FORMATS.TEMPERATUR, mtype=TYPES.NUMBER, device=DEVICES.W2, params=PARAMS_BIVALENZTEMP, translation_key="bivalenztemp_ww"),
-] # noqa: E501
+]
 
 MODBUS_ST_ITEMS: list[ModbusItem] = [
     ModbusItem( address=36101, name="Gesamt Energie heute", mformat=FORMATS.NUMBER, mtype=TYPES.SENSOR, device=DEVICES.ST, params=PARAMS_ENERGY, translation_key="ges_energie_heute"),

--- a/custom_components/weishaupt_modbus/items.py
+++ b/custom_components/weishaupt_modbus/items.py
@@ -1,6 +1,6 @@
 """Item classes."""
 
-from .const import TYPES, FORMATS, DeviceConstants, FormatConstants, TypeConstants
+from .const import FORMATS, TYPES, DeviceConstants, FormatConstants, TypeConstants
 
 
 class StatusItem:
@@ -92,7 +92,7 @@ class ApiItem:
         device: DeviceConstants,
         translation_key: str | None = None,
         resultlist=None,
-        params: dict = None,
+        params: dict = None,  # noqa: RUF013
     ) -> None:
         """Initialise ModbusItem."""
         self._name: str = name
@@ -189,7 +189,7 @@ class ApiItem:
         return self._resultlist
 
     def get_text_from_number(self, val: int) -> str:
-        """Get errortext from coresponding number."""
+        """Get errortext from corresponding number."""
         if val is None:
             return None
         if self._resultlist is None:
@@ -200,7 +200,7 @@ class ApiItem:
         return "unbekannt <" + str(val) + ">"
 
     def get_number_from_text(self, val: str) -> int:
-        """Get number of coresponding errortext."""
+        """Get number of corresponding errortext."""
         if self._resultlist is None:
             return None
         for _useless, item in enumerate(self._resultlist):
@@ -209,7 +209,7 @@ class ApiItem:
         return -1
 
     def get_translation_key_from_number(self, val: int) -> str:
-        """Get errortext from coresponding number."""
+        """Get errortext from corresponding number."""
         if val is None:
             return None
         if self._resultlist is None:
@@ -220,7 +220,7 @@ class ApiItem:
         return "unbekannt <" + str(val) + ">"
 
     def get_number_from_translation_key(self, val: str) -> int:
-        """Get number of coresponding errortext."""
+        """Get number of corresponding errortext."""
         if val is None:
             return None
         if self._resultlist is None:
@@ -234,7 +234,7 @@ class ApiItem:
 class WebItem(ApiItem):
     """Represents an ApiItem.
 
-    Used for generating entitys.
+    Used for generating entities.
     """
 
     _webif_group = None
@@ -248,18 +248,19 @@ class WebItem(ApiItem):
         webif_group: str,
         translation_key: str | None = None,
         resultlist=None,
-        params: dict = None,
+        params: dict = None,  # noqa: RUF013
     ) -> None:
-        """WebifItem is used to generate sensors for an Webinterface value.
+        """WebifItem is used to generate sensors for an Web interface value.
 
         Args:
-            name (str): Name of the entity
-            mformat (FormatConstants): Format of the entity
-            mtype (TypeConstants): Type of the entity
-            device (DeviceConstants): Device the entity belongs to
-            webif_group (str): Group of entitys this one should be fetched with.
-            translation_key (str, optional): Translation Key of the entity
-            resultlist (_type_, optional): Resultlist of the entity
+            name (str): Name of the entity.
+            mformat (FormatConstants): Format of the entity.
+            mtype (TypeConstants): Type of the entity.
+            device (DeviceConstants): Device the entity belongs to.
+            webif_group (str): Group of entities this one should be fetched with.
+            translation_key (str, optional): Translation key of the entity. Defaults to None.
+            resultlist (optional): Result list of the entity. Defaults to None.
+            params (dict, optional): Additional parameters for the entity. Defaults to None.
 
         """
         ApiItem.__init__(
@@ -285,6 +286,7 @@ class WebItem(ApiItem):
         self._webif_group: str = val
 
     def get_value(self, val):
+        """Get the value based on the format."""
         if self._format in [
             FORMATS.TEMPERATUR,
             FORMATS.PERCENTAGE,
@@ -307,18 +309,19 @@ class ModbusItem(ApiItem):
         device: DeviceConstants,
         translation_key: str,
         resultlist=None,
-        params: dict = None,
+        params: dict = None,  # noqa: RUF013
     ) -> None:
-        """ModbusItem is used to generate entitys.
+        """ModbusItem is used to generate entities.
 
         Args:
             address (int): Modbus Address of the item.
             name (str): Name of the entity.
-            mformat (FormatConstants): Format of the entity
+            mformat (FormatConstants): Format of the entity.
             mtype (TypeConstants): Type of the entity.
-            device (DeviceConstants): Device the entity belongs to
-            translation_key (str): Translation key of the entity
-            resultlist (_type_, optional): Resultlist of the entity_. Defaults to None.
+            device (DeviceConstants): Device the entity belongs to.
+            translation_key (str): Translation key of the entity.
+            resultlist (optional): Result list of the entity. Defaults to None.
+            params (dict, optional): Additional parameters for the entity. Defaults to None.
 
         """
         ApiItem.__init__(

--- a/custom_components/weishaupt_modbus/kennfeld.py
+++ b/custom_components/weishaupt_modbus/kennfeld.py
@@ -1,15 +1,13 @@
 """Kennfeld."""
 
-import logging
 import json
-import aiofiles
+import logging
 
+import aiofiles
 import numpy as np
 from numpy.polynomial import Chebyshev
 
-
 from .configentry import MyConfigEntry
-
 from .const import CONF, CONST
 
 logging.basicConfig()
@@ -17,7 +15,7 @@ log = logging.getLogger(__name__)
 
 SPLINE_AVAILABLE = True
 try:
-    import scipy  # noqa F401 pylint: disable=W0611
+    import scipy  # noqa: F401 pylint: disable=unused-import
 except ModuleNotFoundError:
     log.warning(
         "Scipy not available, use less precise Chebyshef interpolation for heating power"
@@ -29,7 +27,7 @@ if SPLINE_AVAILABLE is True:
     log.info(
         "Scipy available, use precise cubic spline interpolation for heating power"
     )
-    from scipy.interpolate import CubicSpline  # pylint: disable=E0401
+    from scipy.interpolate import CubicSpline  # pylint: disable=unused-import
 
 MATPLOTLIB_AVAILABLE = True
 try:
@@ -92,7 +90,7 @@ class PowerMap:
 
     # the aim is generating a 2D power map that gives back the actual power for a certain flow temperature and a given outside temperature
     # the map should have values on every integer temperature point
-    # at first, all flow temoperatures are lineary interpolated
+    # at first, all flow temperatures are linearly interpolated
 
     _config_entry = None
     _steps = None
@@ -149,7 +147,7 @@ class PowerMap:
         self._interp_y = []
 
         # build the matrix with linear interpolated samples
-        # 1st and last row are populated by known values from diagrem, the rest is zero
+        # 1st and last row are populated by known values from diagram, the rest is zero
         self._interp_y.append(self.known_y[0])
         v = np.linspace(0, self._steps - 3, self._steps - 2)
         for _idx in v:
@@ -198,7 +196,7 @@ class PowerMap:
         return self._max_power[int(y)][int(x)]
 
     def plot_kennfeld_to_file(self):
-        """plots the kennfeld file into png image for display"""
+        """Plot the kennfeld file into png image for display."""
         plt.plot(self._all_t, np.transpose(self._max_power))
         plt.ylabel("Max Power")
         plt.xlabel("°C")

--- a/custom_components/weishaupt_modbus/migrate_helpers.py
+++ b/custom_components/weishaupt_modbus/migrate_helpers.py
@@ -1,19 +1,15 @@
-"""Helpers for entity migration"""
+"""Helpers for entity migration."""
 
 import logging
 
-from homeassistant.util import slugify
-from homeassistant.helpers import entity_registry as er
 from homeassistant.core import callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
 
-from .const import (
-    CONF,
-    CONST,
-    TYPES,
-)
+from .configentry import MyConfigEntry
+from .const import CONF, CONST, TYPES
 from .hpconst import reverse_device_list
 from .items import ModbusItem
-from .configentry import MyConfigEntry
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
@@ -22,7 +18,7 @@ log = logging.getLogger(__name__)
 def create_new_entity_id(
     config_entry: MyConfigEntry, modbus_item: ModbusItem, platform: str, device: str
 ):
-    """created an entity ID according to new style"""
+    """Create an entity ID according to new style."""
     dev_postfix = "_" + config_entry.data[CONF.DEVICE_POSTFIX]
     if dev_postfix == "_":
         dev_postfix = ""
@@ -45,7 +41,7 @@ def create_new_entity_id(
 
 
 def create_unique_id(config_entry: MyConfigEntry, modbus_item: ModbusItem):
-    """created an UID according to old style"""
+    """Create an UID according to old style."""
     dev_postfix = "_" + config_entry.data[CONF.DEVICE_POSTFIX]
 
     if dev_postfix == "_":

--- a/custom_components/weishaupt_modbus/modbusobject.py
+++ b/custom_components/weishaupt_modbus/modbusobject.py
@@ -11,7 +11,7 @@ from pymodbus import ExceptionResponse, ModbusException
 from pymodbus.client import AsyncModbusTcpClient
 
 from .configentry import MyConfigEntry
-from .const import FORMATS, TYPES, CONF
+from .const import CONF, FORMATS, TYPES
 from .items import ModbusItem
 
 logging.basicConfig()
@@ -19,10 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class ModbusAPI:
-    """
-    ModbusAPI class that provides a connection to the modbus,
-    which is used by the ModbusItems.
-    """
+    """ModbusAPI class provides a connection to the modbus, which is used by the ModbusItems."""
 
     def __init__(self, config_entry: MyConfigEntry) -> None:
         """Construct ModbusAPI.
@@ -44,12 +41,11 @@ class ModbusAPI:
                 await self._modbus_client.connect()
                 if self._modbus_client.connected:
                     return self._modbus_client.connected
-                else:
-                    await asyncio.sleep(1)
-            log.info("Connection to heatpump succeeded")
+                await asyncio.sleep(1)
+            log.info("Connection to heat pump succeeded")
 
         except ModbusException:
-            log.warning("Connection to heatpump failed")
+            log.warning("Connection to heat pump failed")
             return None
         return self._modbus_client.connected
 
@@ -58,9 +54,9 @@ class ModbusAPI:
         try:
             self._modbus_client.close()
         except ModbusException:
-            log.warning("Closing connection to heatpump failed")
+            log.warning("Closing connection to heat pump failed")
             return False
-        log.info("Connection to heatpump closed")
+        log.info("Connection to heat pump closed")
         return True
 
     def get_device(self):
@@ -100,11 +96,11 @@ class ModbusObject:
                 return val
 
     def check_temperature(self, val) -> int:
-        """Check availability of temperature item and translate
-        return value to valid int
+        """Check availability of temperature item and translate return value to valid int.
 
         :param val: The value from the modbus
-        :type val: int"""
+        :type val: int
+        """
         match val:
             case -32768:
                 # No Sensor installed, remove it from the list
@@ -126,17 +122,17 @@ class ModbusObject:
                 return val
 
     def check_percentage(self, val) -> int:
-        """Check availability of percentage item and translate
-        return value to valid int
+        """Check availability of percentage item and translate.
 
+        return value to valid int
         :param val: The value from the modbus
-        :type val: int"""
+        :type val: int
+        """
         if val == 65535:
             self._modbus_item.is_invalid = True
             return None
-        else:
-            self._modbus_item.is_invalid = False
-            return val
+        self._modbus_item.is_invalid = False
+        return val
 
     def check_status(self, val) -> int:
         """Check general availability of item."""
@@ -154,11 +150,11 @@ class ModbusObject:
                 return val
 
     def validate_modbus_answer(self, mbr) -> int:
-        """Check if there's a valid answer from modbus and
-        translate it to a valid int depending from type
+        """Check if there's a valid answer from modbus and translate it to a valid int depending from type.
 
         :param mbr: The modbus response
-        :type mbr: modbus response"""
+        :type mbr: modbus response
+        """
         val = None
         if mbr.isError():
             myexception_code: ExceptionResponse = mbr
@@ -181,7 +177,7 @@ class ModbusObject:
             # THIS IS NOT A PYTHON EXCEPTION, but a valid modbus message
         if len(mbr.registers) > 0:
             val = self.check_valid_result(mbr.registers[0])
-            return val
+        return val
 
     @property
     async def value(self):
@@ -216,14 +212,15 @@ class ModbusObject:
                     str(exc),
                     str(self._modbus_item.name),
                 )
-                return None
+        return None
 
     # @value.setter
     async def setvalue(self, value) -> None:
         """Set the value of the modbus register, does nothing when not R/W.
 
         :param val: The value to write to the modbus
-        :type val: int"""
+        :type val: int
+        """
         if self._modbus_client is None:
             return
         try:

--- a/custom_components/weishaupt_modbus/translations/en.json
+++ b/custom_components/weishaupt_modbus/translations/en.json
@@ -1,1612 +1,1612 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Account is already configured"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "Device-Postfix": "Device postfix",
-                    "Heizkreis 2": "2nd heating circuit",
-                    "Heizkreis 3": "3rd heating circuit",
-                    "Heizkreis 4": "4th heating circuit",
-                    "Heizkreis 5": "5th heating circuit",
-                    "Host": "Host!",
-                    "Kennfeld-File": "Filename Kennfeld",
-                    "Name-Device-Prefix": "Name Device Prefix",
-                    "Name-Topic-Prefix": "Name Topic Prefix",
-                    "Port": "Port",
-                    "Prefix": "Prefix",
-                    "enable-webif": "enable experimental webif?",
-                    "Web-IF-Token": "four letter web-IF token, see readme"
-                }
-            }
-        }
+  "config": {
+    "abort": {
+      "already_configured": "Account is already configured"
     },
-    "device": {
-        "dev_ein_aus": {
-            "name": "WH Input/output{postfix}"
-        },
-        "dev_heizkreis": {
-            "name": "WH Heating circuit{postfix}"
-        },
-        "dev_heizkreis2": {
-            "name": "WH Heating circuit2{postfix}"
-        },
-        "dev_heizkreis3": {
-            "name": "WH Heating circuit3{postfix}"
-        },
-        "dev_heizkreis4": {
-            "name": "WH Heating circuit4{postfix}"
-        },
-        "dev_heizkreis5": {
-            "name": "WH Heating circuit5{postfix}"
-        },
-        "dev_statistik": {
-            "name": "WH Statistics{postfix}"
-        },
-        "dev_system": {
-            "name": "WH System{postfix}"
-        },
-        "dev_unknown": {
-            "name": "WH Unknown{postfix}"
-        },
-        "dev_waermeerzeuger2": {
-            "name": "WH 2nd heat source{postfix}"
-        },
-        "dev_waermepumpe": {
-            "name": "WH Heat pump{postfix}"
-        },
-        "dev_warmwasser": {
-            "name": "WH Hot water{postfix}"
-        }
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
-    "entity": {
-        "number": {
-            "bivalenztemp": {
-                "name": "{prefix}Bivalence temperature"
-            },
-            "bivalenztemp_ww": {
-                "name": "{prefix}Bivalence temperature HW"
-            },
-            "grenztemp": {
-                "name": "{prefix}Limit temperature"
-            },
-            "heizkennlinie": {
-                "name": "{prefix}Heating curve"
-            },
-            "heizkennlinie2": {
-                "name": "{prefix}Heating curve2"
-            },
-            "heizkennlinie3": {
-                "name": "{prefix}Heating curve3"
-            },
-            "heizkennlinie4": {
-                "name": "{prefix}Heating curve4"
-            },
-            "heizkennlinie5": {
-                "name": "{prefix}Heating curve5"
-            },
-            "raum_soll_temp_absenk": {
-                "name": "{prefix}Room setpoint temperature lowering"
-            },
-            "raum_soll_temp_absenk2": {
-                "name": "{prefix}Room setpoint temperature lowering2"
-            },
-            "raum_soll_temp_absenk3": {
-                "name": "{prefix}Room setpoint temperature lowering3"
-            },
-            "raum_soll_temp_absenk4": {
-                "name": "{prefix}Room setpoint temperature lowering4"
-            },
-            "raum_soll_temp_absenk5": {
-                "name": "{prefix}Room setpoint temperature lowering5"
-            },
-            "raum_soll_temp_komf": {
-                "name": "{prefix}Room setpoint temperature comfort"
-            },
-            "raum_soll_temp_komf2": {
-                "name": "{prefix}Room setpoint temperature comfort2"
-            },
-            "raum_soll_temp_komf3": {
-                "name": "{prefix}Room setpoint temperature comfort3"
-            },
-            "raum_soll_temp_komf4": {
-                "name": "{prefix}Room setpoint temperature comfort4"
-            },
-            "raum_soll_temp_komf5": {
-                "name": "{prefix}Room setpoint temperature comfort5"
-            },
-            "raum_soll_temp_normal": {
-                "name": "{prefix}Room setpoint temperature normal"
-            },
-            "raum_soll_temp_normal2": {
-                "name": "{prefix}Room setpoint temperature normal2"
-            },
-            "raum_soll_temp_normal3": {
-                "name": "{prefix}Room setpoint temperature normal3"
-            },
-            "raum_soll_temp_normal4": {
-                "name": "{prefix}Room setpoint temperature normal4"
-            },
-            "raum_soll_temp_normal5": {
-                "name": "{prefix}Room setpoint temperature normal5"
-            },
-            "sgr_anhebung": {
-                "name": "{prefix}SG Ready increase"
-            },
-            "so_wi_umschalt": {
-                "name": "{prefix}Summer winter changeover"
-            },
-            "so_wi_umschalt2": {
-                "name": "{prefix}Summer winter changeover2"
-            },
-            "so_wi_umschalt3": {
-                "name": "{prefix}Summer winter changeover3"
-            },
-            "so_wi_umschalt4": {
-                "name": "{prefix}Summer winter changeover4"
-            },
-            "so_wi_umschalt5": {
-                "name": "{prefix}Summer winter changeover5"
-            },
-            "ww_absenk": {
-                "name": "{prefix}Hot water lowering"
-            },
-            "ww_normal": {
-                "name": "{prefix}Hot water normal"
-            }
-        },
-        "select": {
-            "hz_operationmode": {
-                "name": "{prefix}Operation mode",
-                "state": {
-                    "hz_operationmode_lowering": "Lowering mode",
-                    "hz_operationmode_automatic": "Automatic",
-                    "hz_operationmode_normal": "Normal",
-                    "hz_operationmode_standby": "Standby",
-                    "hz_operationmode_comfort": "Comfort"
-                }
-            },
-            "hz_operationmode2": {
-                "name": "{prefix}Operation mode2",
-                "state": {
-                    "hz_operationmode_lowering": "Lowering mode",
-                    "hz_operationmode_automatic": "Automatic",
-                    "hz_operationmode_normal": "Normal",
-                    "hz_operationmode_standby": "Standby",
-                    "hz_operationmode_comfort": "Comfort"
-                }
-            },
-            "hz_operationmode3": {
-                "name": "{prefix}Operation mode3",
-                "state": {
-                    "hz_operationmode_lowering": "Lowering mode",
-                    "hz_operationmode_automatic": "Automatic",
-                    "hz_operationmode_normal": "Normal",
-                    "hz_operationmode_standby": "Standby",
-                    "hz_operationmode_comfort": "Comfort"
-                }
-            },
-            "hz_operationmode4": {
-                "name": "{prefix}Operation mode4",
-                "state": {
-                    "hz_operationmode_lowering": "Lowering mode",
-                    "hz_operationmode_automatic": "Automatic",
-                    "hz_operationmode_normal": "Normal",
-                    "hz_operationmode_standby": "Standby",
-                    "hz_operationmode_comfort": "Comfort"
-                }
-            },
-            "hz_operationmode5": {
-                "name": "{prefix}Operation mode5",
-                "state": {
-                    "hz_operationmode_lowering": "Lowering mode",
-                    "hz_operationmode_automatic": "Automatic",
-                    "hz_operationmode_normal": "Normal",
-                    "hz_operationmode_standby": "Standby",
-                    "hz_operationmode_comfort": "Comfort"
-                }
-            },
-            "party_pause": {
-                "name": "{prefix}Pause / Party",
-                "state": {
-                    "hz_party_0_5": "Party 0.5h",
-                    "hz_party_1": "Party 1.0h",
-                    "hz_party_10": "Party 10.0h",
-                    "hz_party_10_5": "Party 10.5h",
-                    "hz_party_11": "Party 11.0h",
-                    "hz_party_11_5": "Party 11.5h",
-                    "hz_party_12": "Party 12.0h",
-                    "hz_party_1_5": "Party 1.5h",
-                    "hz_party_2": "Party 2.0h",
-                    "hz_party_2_5": "Party 2.5h",
-                    "hz_party_3": "Party 3.0h",
-                    "hz_party_3_5": "Party 3.5h",
-                    "hz_party_4": "Party 4.0h",
-                    "hz_party_4_5": "Party 4.5h",
-                    "hz_party_5": "Party 5.0h",
-                    "hz_party_5_5": "Party 5.5h",
-                    "hz_party_6": "Party 6.0h",
-                    "hz_party_6_5": "Party 6.5h",
-                    "hz_party_7": "Party 7.0h",
-                    "hz_party_7_5": "Party 7.5h",
-                    "hz_party_8": "Party 8.0h",
-                    "hz_party_8_5": "Party 8.5h",
-                    "hz_party_9": "Party 9.0h",
-                    "hz_party_9_5": "Party 9.5h",
-                    "hz_party_pause_auto": "Automatic",
-                    "hz_pause_0_5": "Pause 0.5h",
-                    "hz_pause_1": "Pause 1.0h",
-                    "hz_pause_10": "Pause 10.0h",
-                    "hz_pause_10_5": "Pause 10.5h",
-                    "hz_pause_11": "Pause 11.0h",
-                    "hz_pause_11_5": "Pause 11.5h",
-                    "hz_pause_12": "Pause 12.0h",
-                    "hz_pause_1_5": "Pause 1.5h",
-                    "hz_pause_2": "Pause 2.0h",
-                    "hz_pause_2_5": "Pause 2.5h",
-                    "hz_pause_3": "Pause 3.0h",
-                    "hz_pause_3_5": "Pause 3.5h",
-                    "hz_pause_4": "Pause 4.0h",
-                    "hz_pause_4_5": "Pause 4.5h",
-                    "hz_pause_5": "Pause 5.0h",
-                    "hz_pause_5_5": "Pause 5.5h",
-                    "hz_pause_6": "Pause 6.0h",
-                    "hz_pause_6_5": "Pause 6.5h",
-                    "hz_pause_7": "Pause 7.0h",
-                    "hz_pause_7_5": "Pause 7.5h",
-                    "hz_pause_8": "Pause 8.0h",
-                    "hz_pause_8_5": "Pause 8.5h",
-                    "hz_pause_9": "Pause 9.0h",
-                    "hz_pause_9_5": "Pause 9.5h"
-                }
-            },
-            "party_pause2": {
-                "name": "{prefix}Pause / Party2",
-                "state": {
-                    "hz_party_0_5": "Party 0.5h",
-                    "hz_party_1": "Party 1.0h",
-                    "hz_party_10": "Party 10.0h",
-                    "hz_party_10_5": "Party 10.5h",
-                    "hz_party_11": "Party 11.0h",
-                    "hz_party_11_5": "Party 11.5h",
-                    "hz_party_12": "Party 12.0h",
-                    "hz_party_1_5": "Party 1.5h",
-                    "hz_party_2": "Party 2.0h",
-                    "hz_party_2_5": "Party 2.5h",
-                    "hz_party_3": "Party 3.0h",
-                    "hz_party_3_5": "Party 3.5h",
-                    "hz_party_4": "Party 4.0h",
-                    "hz_party_4_5": "Party 4.5h",
-                    "hz_party_5": "Party 5.0h",
-                    "hz_party_5_5": "Party 5.5h",
-                    "hz_party_6": "Party 6.0h",
-                    "hz_party_6_5": "Party 6.5h",
-                    "hz_party_7": "Party 7.0h",
-                    "hz_party_7_5": "Party 7.5h",
-                    "hz_party_8": "Party 8.0h",
-                    "hz_party_8_5": "Party 8.5h",
-                    "hz_party_9": "Party 9.0h",
-                    "hz_party_9_5": "Party 9.5h",
-                    "hz_party_pause_auto": "Automatic",
-                    "hz_pause_0_5": "Pause 0.5h",
-                    "hz_pause_1": "Pause 1.0h",
-                    "hz_pause_10": "Pause 10.0h",
-                    "hz_pause_10_5": "Pause 10.5h",
-                    "hz_pause_11": "Pause 11.0h",
-                    "hz_pause_11_5": "Pause 11.5h",
-                    "hz_pause_12": "Pause 12.0h",
-                    "hz_pause_1_5": "Pause 1.5h",
-                    "hz_pause_2": "Pause 2.0h",
-                    "hz_pause_2_5": "Pause 2.5h",
-                    "hz_pause_3": "Pause 3.0h",
-                    "hz_pause_3_5": "Pause 3.5h",
-                    "hz_pause_4": "Pause 4.0h",
-                    "hz_pause_4_5": "Pause 4.5h",
-                    "hz_pause_5": "Pause 5.0h",
-                    "hz_pause_5_5": "Pause 5.5h",
-                    "hz_pause_6": "Pause 6.0h",
-                    "hz_pause_6_5": "Pause 6.5h",
-                    "hz_pause_7": "Pause 7.0h",
-                    "hz_pause_7_5": "Pause 7.5h",
-                    "hz_pause_8": "Pause 8.0h",
-                    "hz_pause_8_5": "Pause 8.5h",
-                    "hz_pause_9": "Pause 9.0h",
-                    "hz_pause_9_5": "Pause 9.5h"
-                }
-            },
-            "party_pause3": {
-                "name": "{prefix}Pause / Party3",
-                "state": {
-                    "hz_party_0_5": "Party 0.5h",
-                    "hz_party_1": "Party 1.0h",
-                    "hz_party_10": "Party 10.0h",
-                    "hz_party_10_5": "Party 10.5h",
-                    "hz_party_11": "Party 11.0h",
-                    "hz_party_11_5": "Party 11.5h",
-                    "hz_party_12": "Party 12.0h",
-                    "hz_party_1_5": "Party 1.5h",
-                    "hz_party_2": "Party 2.0h",
-                    "hz_party_2_5": "Party 2.5h",
-                    "hz_party_3": "Party 3.0h",
-                    "hz_party_3_5": "Party 3.5h",
-                    "hz_party_4": "Party 4.0h",
-                    "hz_party_4_5": "Party 4.5h",
-                    "hz_party_5": "Party 5.0h",
-                    "hz_party_5_5": "Party 5.5h",
-                    "hz_party_6": "Party 6.0h",
-                    "hz_party_6_5": "Party 6.5h",
-                    "hz_party_7": "Party 7.0h",
-                    "hz_party_7_5": "Party 7.5h",
-                    "hz_party_8": "Party 8.0h",
-                    "hz_party_8_5": "Party 8.5h",
-                    "hz_party_9": "Party 9.0h",
-                    "hz_party_9_5": "Party 9.5h",
-                    "hz_party_pause_auto": "Automatic",
-                    "hz_pause_0_5": "Pause 0.5h",
-                    "hz_pause_1": "Pause 1.0h",
-                    "hz_pause_10": "Pause 10.0h",
-                    "hz_pause_10_5": "Pause 10.5h",
-                    "hz_pause_11": "Pause 11.0h",
-                    "hz_pause_11_5": "Pause 11.5h",
-                    "hz_pause_12": "Pause 12.0h",
-                    "hz_pause_1_5": "Pause 1.5h",
-                    "hz_pause_2": "Pause 2.0h",
-                    "hz_pause_2_5": "Pause 2.5h",
-                    "hz_pause_3": "Pause 3.0h",
-                    "hz_pause_3_5": "Pause 3.5h",
-                    "hz_pause_4": "Pause 4.0h",
-                    "hz_pause_4_5": "Pause 4.5h",
-                    "hz_pause_5": "Pause 5.0h",
-                    "hz_pause_5_5": "Pause 5.5h",
-                    "hz_pause_6": "Pause 6.0h",
-                    "hz_pause_6_5": "Pause 6.5h",
-                    "hz_pause_7": "Pause 7.0h",
-                    "hz_pause_7_5": "Pause 7.5h",
-                    "hz_pause_8": "Pause 8.0h",
-                    "hz_pause_8_5": "Pause 8.5h",
-                    "hz_pause_9": "Pause 9.0h",
-                    "hz_pause_9_5": "Pause 9.5h"
-                }
-            },
-            "party_pause4": {
-                "name": "{prefix}Pause / Party4",
-                "state": {
-                    "hz_party_0_5": "Party 0.5h",
-                    "hz_party_1": "Party 1.0h",
-                    "hz_party_10": "Party 10.0h",
-                    "hz_party_10_5": "Party 10.5h",
-                    "hz_party_11": "Party 11.0h",
-                    "hz_party_11_5": "Party 11.5h",
-                    "hz_party_12": "Party 12.0h",
-                    "hz_party_1_5": "Party 1.5h",
-                    "hz_party_2": "Party 2.0h",
-                    "hz_party_2_5": "Party 2.5h",
-                    "hz_party_3": "Party 3.0h",
-                    "hz_party_3_5": "Party 3.5h",
-                    "hz_party_4": "Party 4.0h",
-                    "hz_party_4_5": "Party 4.5h",
-                    "hz_party_5": "Party 5.0h",
-                    "hz_party_5_5": "Party 5.5h",
-                    "hz_party_6": "Party 6.0h",
-                    "hz_party_6_5": "Party 6.5h",
-                    "hz_party_7": "Party 7.0h",
-                    "hz_party_7_5": "Party 7.5h",
-                    "hz_party_8": "Party 8.0h",
-                    "hz_party_8_5": "Party 8.5h",
-                    "hz_party_9": "Party 9.0h",
-                    "hz_party_9_5": "Party 9.5h",
-                    "hz_party_pause_auto": "Automatic",
-                    "hz_pause_0_5": "Pause 0.5h",
-                    "hz_pause_1": "Pause 1.0h",
-                    "hz_pause_10": "Pause 10.0h",
-                    "hz_pause_10_5": "Pause 10.5h",
-                    "hz_pause_11": "Pause 11.0h",
-                    "hz_pause_11_5": "Pause 11.5h",
-                    "hz_pause_12": "Pause 12.0h",
-                    "hz_pause_1_5": "Pause 1.5h",
-                    "hz_pause_2": "Pause 2.0h",
-                    "hz_pause_2_5": "Pause 2.5h",
-                    "hz_pause_3": "Pause 3.0h",
-                    "hz_pause_3_5": "Pause 3.5h",
-                    "hz_pause_4": "Pause 4.0h",
-                    "hz_pause_4_5": "Pause 4.5h",
-                    "hz_pause_5": "Pause 5.0h",
-                    "hz_pause_5_5": "Pause 5.5h",
-                    "hz_pause_6": "Pause 6.0h",
-                    "hz_pause_6_5": "Pause 6.5h",
-                    "hz_pause_7": "Pause 7.0h",
-                    "hz_pause_7_5": "Pause 7.5h",
-                    "hz_pause_8": "Pause 8.0h",
-                    "hz_pause_8_5": "Pause 8.5h",
-                    "hz_pause_9": "Pause 9.0h",
-                    "hz_pause_9_5": "Pause 9.5h"
-                }
-            },
-            "party_pause5": {
-                "name": "{prefix}Pause / Party5",
-                "state": {
-                    "hz_party_0_5": "Party 0.5h",
-                    "hz_party_1": "Party 1.0h",
-                    "hz_party_10": "Party 10.0h",
-                    "hz_party_10_5": "Party 10.5h",
-                    "hz_party_11": "Party 11.0h",
-                    "hz_party_11_5": "Party 11.5h",
-                    "hz_party_12": "Party 12.0h",
-                    "hz_party_1_5": "Party 1.5h",
-                    "hz_party_2": "Party 2.0h",
-                    "hz_party_2_5": "Party 2.5h",
-                    "hz_party_3": "Party 3.0h",
-                    "hz_party_3_5": "Party 3.5h",
-                    "hz_party_4": "Party 4.0h",
-                    "hz_party_4_5": "Party 4.5h",
-                    "hz_party_5": "Party 5.0h",
-                    "hz_party_5_5": "Party 5.5h",
-                    "hz_party_6": "Party 6.0h",
-                    "hz_party_6_5": "Party 6.5h",
-                    "hz_party_7": "Party 7.0h",
-                    "hz_party_7_5": "Party 7.5h",
-                    "hz_party_8": "Party 8.0h",
-                    "hz_party_8_5": "Party 8.5h",
-                    "hz_party_9": "Party 9.0h",
-                    "hz_party_9_5": "Party 9.5h",
-                    "hz_party_pause_auto": "Automatic",
-                    "hz_pause_0_5": "Pause 0.5h",
-                    "hz_pause_1": "Pause 1.0h",
-                    "hz_pause_10": "Pause 10.0h",
-                    "hz_pause_10_5": "Pause 10.5h",
-                    "hz_pause_11": "Pause 11.0h",
-                    "hz_pause_11_5": "Pause 11.5h",
-                    "hz_pause_12": "Pause 12.0h",
-                    "hz_pause_1_5": "Pause 1.5h",
-                    "hz_pause_2": "Pause 2.0h",
-                    "hz_pause_2_5": "Pause 2.5h",
-                    "hz_pause_3": "Pause 3.0h",
-                    "hz_pause_3_5": "Pause 3.5h",
-                    "hz_pause_4": "Pause 4.0h",
-                    "hz_pause_4_5": "Pause 4.5h",
-                    "hz_pause_5": "Pause 5.0h",
-                    "hz_pause_5_5": "Pause 5.5h",
-                    "hz_pause_6": "Pause 6.0h",
-                    "hz_pause_6_5": "Pause 6.5h",
-                    "hz_pause_7": "Pause 7.0h",
-                    "hz_pause_7_5": "Pause 7.5h",
-                    "hz_pause_8": "Pause 8.0h",
-                    "hz_pause_8_5": "Pause 8.5h",
-                    "hz_pause_9": "Pause 9.0h",
-                    "hz_pause_9_5": "Pause 9.5h"
-                }
-            },
-            "sys_operationmode": {
-                "name": "{prefix}System operation mode",
-                "state": {
-                    "sys_operationmode_2ndheatsource": "2nd heat source",
-                    "sys_operationmode_automatic": "Automatic",
-                    "sys_operationmode_heating": "Heating",
-                    "sys_operationmode_cooling": "Cooling",
-                    "sys_operationmode_summer": "Summer",
-                    "sys_operationmode_standby": "Standby"
-                }
-            },
-            "ww_push": {
-                "name": "{prefix}Hot water Push",
-                "state": {
-                    "ww_push_10": "10 min",
-                    "ww_push_100": "100 min",
-                    "ww_push_105": "105 min",
-                    "ww_push_110": "110 min",
-                    "ww_push_115": "115 min",
-                    "ww_push_120": "120 min",
-                    "ww_push_125": "125 min",
-                    "ww_push_130": "130 min",
-                    "ww_push_135": "135 min",
-                    "ww_push_140": "140 min",
-                    "ww_push_145": "145 min",
-                    "ww_push_15": "15 min",
-                    "ww_push_150": "150 min",
-                    "ww_push_155": "155 min",
-                    "ww_push_160": "160 min",
-                    "ww_push_165": "165 min",
-                    "ww_push_170": "170 min",
-                    "ww_push_175": "175 min",
-                    "ww_push_180": "180 min",
-                    "ww_push_185": "185 min",
-                    "ww_push_190": "190 min",
-                    "ww_push_195": "195 min",
-                    "ww_push_20": "20 min",
-                    "ww_push_200": "200 min",
-                    "ww_push_205": "205 min",
-                    "ww_push_210": "210 min",
-                    "ww_push_215": "215 min",
-                    "ww_push_220": "220 min",
-                    "ww_push_225": "225 min",
-                    "ww_push_230": "230 min",
-                    "ww_push_235": "235 min",
-                    "ww_push_25": "25 min",
-                    "ww_push_30": "30 min",
-                    "ww_push_35": "35 min",
-                    "ww_push_40": "40 min",
-                    "ww_push_45": "45 min",
-                    "ww_push_5": "5 min",
-                    "ww_push_50": "50 min",
-                    "ww_push_55": "55 min",
-                    "ww_push_60": "60 min",
-                    "ww_push_65": "65 min",
-                    "ww_push_70": "70 min",
-                    "ww_push_75": "75 min",
-                    "ww_push_80": "80 min",
-                    "ww_push_85": "85 min",
-                    "ww_push_90": "90 min",
-                    "ww_push_95": "95 min",
-                    "ww_push_aus": "off"
-                }
-            }
-        },
-        "sensor": {
-            "abtau_energie_gester": {
-                "name": "{prefix}Defrost energy yesterday"
-            },
-            "abtau_energie_heute": {
-                "name": "{prefix}Defrost energy today"
-            },
-            "abtau_energie_jahr": {
-                "name": "{prefix}Defrost energy year"
-            },
-            "abtau_energie_monat": {
-                "name": "{prefix}Defrost energy month"
-            },
-            "adr31106": {
-                "name": "{prefix}Adr. 31106"
-            },
-            "adr311062": {
-                "name": "{prefix}Adr. 311062"
-            },
-            "adr311063": {
-                "name": "{prefix}Adr. 311063"
-            },
-            "adr311064": {
-                "name": "{prefix}Adr. 311064"
-            },
-            "adr311065": {
-                "name": "{prefix}Adr. 311065"
-            },
-            "adr36801": {
-                "name": "{prefix}Adr. 36801"
-            },
-            "adr44102": {
-                "name": "{prefix}Configuration EP1",
-                "state": {
-                    "w2_konf_0": "enabled",
-                    "w2_konf_1": "OFF"
-                }
-            },
-            "adr44103": {
-                "name": "{prefix}Configuration EP2",
-                "state": {
-                    "w2_konf_0": "enabled",
-                    "w2_konf_1": "OFF"
-                }
-            },
-            "anf_typ": {
-                "name": "{prefix}Request type",
-                "state": {
-                    "hz_anforderung_aus": "off",
-                    "hz_anforderung_konstant": "constrant",
-                    "hz_anforderung_witterungsgefuehrt": "weather-guided"
-                }
-            },
-            "anf_typ2": {
-                "name": "{prefix}Request type2",
-                "state": {
-                    "hz_anforderung_aus": "off",
-                    "hz_anforderung_konstant": "constrant",
-                    "hz_anforderung_witterungsgefuehrt": "weather-guided"
-                }
-            },
-            "anf_typ3": {
-                "name": "{prefix}Request type3",
-                "state": {
-                    "hz_anforderung_aus": "off",
-                    "hz_anforderung_konstant": "constrant",
-                    "hz_anforderung_witterungsgefuehrt": "weather-guided"
-                }
-            },
-            "anf_typ4": {
-                "name": "{prefix}Request type4",
-                "state": {
-                    "hz_anforderung_aus": "off",
-                    "hz_anforderung_konstant": "constrant",
-                    "hz_anforderung_witterungsgefuehrt": "weather-guided"
-                }
-            },
-            "anf_typ5": {
-                "name": "{prefix}Request type5",
-                "state": {
-                    "hz_anforderung_aus": "off",
-                    "hz_anforderung_konstant": "constrant",
-                    "hz_anforderung_witterungsgefuehrt": "weather-guided"
-                }
-            },
-            "anforderung_vl_regenerativ": {
-                "name": "{prefix}Request(feed regenerative)"
-            },
-            "ausg_h12": {
-                "name": "{prefix}Output H1.2"
-            },
-            "ausg_h13": {
-                "name": "{prefix}Output H1.3"
-            },
-            "ausg_h14": {
-                "name": "{prefix}Output H1.4"
-            },
-            "ausg_h15": {
-                "name": "{prefix}Output H1.5"
-            },
-            "aussentemp": {
-                "name": "{prefix}Outside temperature"
-            },
-            "betriebsanzeige": {
-                "name": "{prefix}Operation indicator",
-                "state": {
-                    "system_operationmode_undefined": "undefined",
-                    "system_operationmode_relaistest": "Relais test",
-                    "system_operationmode_sgtariff": "SG tariff",
-                    "system_operationmode_sgmax": "SG maximum",
-                    "system_operationmode_tariffload": "Tariff load",
-                    "system_operationmode_elevatedoperation": "Elevated operation",
-                    "system_operationmode_standbytime": "Standby time",
-                    "system_operationmode_standby": "Standby",
-                    "system_operationmode_rinse": "Rinse",
-                    "system_operationmode_frosprotection": "Frost protection",
-                    "system_operationmode_heating": "Heating mode",
-                    "system_operationmode_emergencystop": "Emergency stop",
-                    "system_operationmode_hotwater": "Hot water mode",
-                    "system_operationmode_legionellaprotection": "Legionella protection",
-                    "system_operationmode_switchheatingcooling": "Switchover HZ KU",
-                    "system_operationmode_cooling": "Cooling mode",
-                    "system_operationmode_passivecooling": "Passive cooling",
-                    "system_operationmode_summer": "Summer mode",
-                    "system_operationmode_swimmingpool": "Swimming pool mode",
-                    "system_operationmode_vacation": "Vacation",
-                    "system_operationmode_screedprogram": "Screed program",
-                    "system_operationmode_locked": "Locked",
-                    "system_operationmode_diagnosis": "Diagnosis",
-                    "system_operationmode_lockedat": "Lock AT",
-                    "system_operationmode_lockedsummer": "Lock summer",
-                    "system_operationmode_lockedwinter": "Winter lock",
-                    "system_operationmode_applicationlimit": "Application limit",
-                    "system_operationmode_lockedcv": "HK block",
-                    "system_operationmode_lowering": "Lowering mode",
-                    "system_operationmode_regenerativeflow": "Regenerative flow",
-                    "system_operationmode_manual": "Manual mode",
-                    "system_operationmode_oilrecirculation": "Oil recirculation",
-                    "system_operationmode_manualheating": "Manual heating",
-                    "system_operationmode_manualcooling": "Manual cooling",
-                    "system_operationmode_manualdefrost": "Manual defrost",
-                    "system_operationmode_defrost": "Defrost",
-                    "system_operationmode_manual2ndheatsource": "2nd heat source"
-                }
-            },
-            "betriebss_e1": {
-                "name": "{prefix}Operation hours E1"
-            },
-            "betriebss_e2": {
-                "name": "{prefix}Operation hours E2"
-            },
-            "eing_de1": {
-                "name": "{prefix}Input DE1",
-                "state": {
-                    "w2_status_aus": "off",
-                    "w2_status_ein": "on"
-                }
-            },
-            "eing_de2": {
-                "name": "{prefix}Input DE2",
-                "state": {
-                    "w2_status_aus": "off",
-                    "w2_status_ein": "on"
-                }
-            },
-            "el_energie_yesterday": {
-                "name": "{prefix}Electr. energy yesterday"
-            },
-            "el_energie_heute": {
-                "name": "{prefix}Electr. energy today"
-            },
-            "el_energie_jahr": {
-                "name": "{prefix}Electr. energy year"
-            },
-            "el_energie_monat": {
-                "name": "{prefix}Electr. energy month"
-            },
-            "fehler": {
-                "name": "{prefix}Fehler",
-                "state": {
-                    "sys_fehler_1": "Refrigerant sensor expansion valve inlet (T1)",
-                    "sys_fehler_10": "High pressure sensor (P2)",
-                    "sys_fehler_101": "Heat pump is being operated outside the operating limits",
-                    "sys_fehler_102": "Maximum defrost time exceeded",
-                    "sys_fehler_103": "Communication refrigeration circuit faulty",
-                    "sys_fehler_104": "discharge gas temperature too high",
-                    "sys_fehler_105": "Current consumption from inverter too high",
-                    "sys_fehler_106": "Current consumption too high",
-                    "sys_fehler_107": "DC voltage on inverter too high",
-                    "sys_fehler_108": "DC voltage on inverter too low",
-                    "sys_fehler_109": "Heat pump is operated outside the permissible voltage range",
-                    "sys_fehler_11": "Medium pressure sensor (P3)",
-                    "sys_fehler_110": "Heat pump is being operated outside the permissible voltage range",
-                    "sys_fehler_111": "High pressure switch has triggered",
-                    "sys_fehler_112": "Inverter has overheated",
-                    "sys_fehler_113": "Inverter has overheated",
-                    "sys_fehler_114": "Position of compressor motor cannot be determined",
-                    "sys_fehler_117": "DC voltage on inverter too low",
-                    "sys_fehler_118": "Current between inverter and compressor is too high",
-                    "sys_fehler_119": "Current consumption from compressor too high Timeout",
-                    "sys_fehler_12": "Cooling expansion valve defective",
-                    "sys_fehler_120": "Inverter temperature too high",
-                    "sys_fehler_121": "Voltage on inverter too low",
-                    "sys_fehler_122": "Modbus configuration error",
-                    "sys_fehler_123": "No Modbus connection",
-                    "sys_fehler_124": "discharge gas temperature too high",
-                    "sys_fehler_127": "Inverter temperature too high",
-                    "sys_fehler_128": "Inverter is overheated",
-                    "sys_fehler_129": "Modbus communication faulty",
-                    "sys_fehler_13": "No communication to the inverter",
-                    "sys_fehler_130": "Modbus communication faulty",
-                    "sys_fehler_133": "Electronics error",
-                    "sys_fehler_135": "High pressure switch defective",
-                    "sys_fehler_136": "Compressor does not match configuration",
-                    "sys_fehler_137": "High pressure switch does not match the configuration",
-                    "sys_fehler_14": "No communication with the outdoor unit",
-                    "sys_fehler_140": "discharge gas temperature too low",
-                    "sys_fehler_143": "Inverter temperature too low",
-                    "sys_fehler_144": "Choke coil temperature too low",
-                    "sys_fehler_15": "High pressure switch has triggered",
-                    "sys_fehler_150": "Compressor current sensor phase U error",
-                    "sys_fehler_151": "Compressor current sensor phase V error",
-                    "sys_fehler_152": "Compressor current sensor phase W error voltage supply from input terminal",
-                    "sys_fehler_153": "Current sensor error",
-                    "sys_fehler_154": "Inverter temperature sensor error",
-                    "sys_fehler_155": "Temperature sensor error",
-                    "sys_fehler_156": "Compressed gas sensor (DT)",
-                    "sys_fehler_157": "No communication to the cooling unit control board",
-                    "sys_fehler_158": "EEPROM memory error",
-                    "sys_fehler_159": "Current consumption too high",
-                    "sys_fehler_16": "Inverter disabled because 10 errors have occurred in the last 10 hours",
-                    "sys_fehler_160": "Heat pump is being operated outside the permissible voltage range",
-                    "sys_fehler_161": "Heat pump is being operated outside the permissible voltage range",
-                    "sys_fehler_162": "DC voltage on inverter too high",
-                    "sys_fehler_163": "DC voltage on inverter too low",
-                    "sys_fehler_164": "High pressure switch has triggered",
-                    "sys_fehler_165": "Phase between input and compressor interrupted",
-                    "sys_fehler_166": "Inverter overheated",
-                    "sys_fehler_167": "Inverter overheated",
-                    "sys_fehler_168": "Compressor configuration error",
-                    "sys_fehler_169": "Compressor current consumption too high",
-                    "sys_fehler_17": "EEPROM memory error",
-                    "sys_fehler_170": "Compressor phase U overvoltage",
-                    "sys_fehler_171": "Compressor phase V overvoltage",
-                    "sys_fehler_172": "Compressor phase W overvoltage",
-                    "sys_fehler_173": "Compressor phase failure",
-                    "sys_fehler_174": "Compressor blocked",
-                    "sys_fehler_175": "Compressor does not start",
-                    "sys_fehler_176": "Irregular voltage supply from inverter",
-                    "sys_fehler_177": "Compressor overloaded",
-                    "sys_fehler_178": "Temperature at discharge gas sensor (DT) too high",
-                    "sys_fehler_179": "Temperature at inverter",
-                    "sys_fehler_18": "No Modbus communication between EC controller and refrigeration unit control board",
-                    "sys_fehler_180": "Compressor blocked",
-                    "sys_fehler_181": "Compressor blocked",
-                    "sys_fehler_182": "Current consumption too high",
-                    "sys_fehler_183": "Current consumption too high",
-                    "sys_fehler_184": "Voltage too high",
-                    "sys_fehler_19": "Heat pump switched off by inverter alarm",
-                    "sys_fehler_2": "Air intake sensor (T2)",
-                    "sys_fehler_20": "Compressor does not match the configuration",
-                    "sys_fehler_21": "Low pressure fault",
-                    "sys_fehler_22": "Insufficient superheat",
-                    "sys_fehler_23": "excessive superheat",
-                    "sys_fehler_24": "EVI too high overheating",
-                    "sys_fehler_25": "Refrigerant quantity too low",
-                    "sys_fehler_26": "High pressure fault",
-                    "sys_fehler_27": "Condensation temperature too low",
-                    "sys_fehler_28": "Condensation temperature too high",
-                    "sys_fehler_29": "Evaporation temperature too low",
-                    "sys_fehler_3": "Heat exchanger sensor AG outlet (T3)",
-                    "sys_fehler_30": "Evaporation temperature too high",
-                    "sys_fehler_32": "Heat pump not compatible",
-                    "sys_fehler_33": "Controller EC has no connection to expansion module EM-HK",
-                    "sys_fehler_4": "Compressor suction gas sensor (T4)",
-                    "sys_fehler_40": "Volume flow too low",
-                    "sys_fehler_41": "Spreizung LWT/Rücklauf negative / four-way valve does not switch back after defrosting; the system locks after 3 warnings)",
-                    "sys_fehler_43": "Fan blocked",
-                    "sys_fehler_44": "Fan speed too low",
-                    "sys_fehler_47": "Communication controller EC to control board refrigeration unit faulty",
-                    "sys_fehler_5": "EVI suction gas sensor (T5)",
-                    "sys_fehler_50": "Outdoor sensor (B1) interrupted",
-                    "sys_fehler_51": "Outdoor sensor (B1) short-circuited",
-                    "sys_fehler_52": "Point sensor (B2) interrupted",
-                    "sys_fehler_53": "Point sensor (B2) short-circuited",
-                    "sys_fehler_54": "Hot water sensor (B3) interrupted",
-                    "sys_fehler_55": "Hot water sensor (B3) short-circuited",
-                    "sys_fehler_56": "Condenser flow sensor (B4) interrupted",
-                    "sys_fehler_57": "Condenser flow sensor (B4) short-circuited",
-                    "sys_fehler_58": "Flow sensor (B7) interrupted",
-                    "sys_fehler_59": "Flow sensor (B7) short-circuited",
-                    "sys_fehler_6": "Refrigerant sensor IG outlet (T6)",
-                    "sys_fehler_60": "Return flow sensor (B9) interrupted",
-                    "sys_fehler_61": "Return flow sensor (B9) short-circuited",
-                    "sys_fehler_64": "Buffer sensor (B11) interrupted",
-                    "sys_fehler_65": "Buffer sensor (B11) short-circuited",
-                    "sys_fehler_65535": "no error",
-                    "sys_fehler_66": "Regenerative mixer sensor (B2.1) interrupted",
-                    "sys_fehler_67": "Regenerative mixer sensor (B2.1) short-circuited",
-                    "sys_fehler_7": "Oil sump sensor (T7)",
-                    "sys_fehler_70": "Second heating circuit flow sensor (B6.2) interrupted",
-                    "sys_fehler_71": "Second heating circuit flow sensor (B6.2) short-circuited",
-                    "sys_fehler_72": "Sensor (T1.2) interrupted",
-                    "sys_fehler_73": "Sensor (T1.2) short-circuited",
-                    "sys_fehler_74": "Sensor (T2.2) interrupted",
-                    "sys_fehler_75": "Sensor (T2.2) short-circuited",
-                    "sys_fehler_8": "Expansion valve EVI",
-                    "sys_fehler_9": "Low pressure sensor (P1)",
-                    "sys_fehler_90": "Analog input AE1 interrupted",
-                    "sys_fehler_91": "Analog input AE1 short-circuited",
-                    "sys_fehler_92": "Analog input AE2 interrupted",
-                    "sys_fehler_93": "Analog input AE2 short-circuited",
-                    "sys_fehler_94": "Analog input AE3 interrupted",
-                    "sys_fehler_95": "Analog input AE3 short-circuited"
-                }
-            },
-            "fehlerfrei": {
-                "name": "{prefix}No error",
-                "state": {
-                    "fehler_aktiv": "Error active",
-                    "stoerungsfreier_betrieb": "Fault-free operation"
-                }
-            },
-            "ges_energie_2_yesterday": {
-                "name": "{prefix}Total energy II yesterday"
-            },
-            "ges_energie_2_heute": {
-                "name": "{prefix}Total energy II today"
-            },
-            "ges_energie_2_jahr": {
-                "name": "{prefix}Total energy II year"
-            },
-            "ges_energie_2_monat": {
-                "name": "{prefix}Total energy II month"
-            },
-            "ges_energie_yesterday": {
-                "name": "{prefix}Total energy yesterday"
-            },
-            "ges_energie_heute": {
-                "name": "{prefix}Total energy today"
-            },
-            "ges_energie_jahr": {
-                "name": "{prefix}Total energy year"
-            },
-            "ges_energie_monat": {
-                "name": "{prefix}Total energy month"
-            },
-            "heiz_energie_getern": {
-                "name": "{prefix}Heating energy yesterday"
-            },
-            "heiz_energie_heute": {
-                "name": "{prefix}Heating energy today"
-            },
-            "heiz_energie_jahr": {
-                "name": "{prefix}Heating energy year"
-            },
-            "heiz_energie_monat": {
-                "name": "{prefix}Heating energy month"
-            },
-            "heiz_konstanttemp": {
-                "name": "{prefix}Heating constant temperature"
-            },
-            "heiz_konstanttemp2": {
-                "name": "{prefix}Heating constant temperature 2"
-            },
-            "heiz_konstanttemp3": {
-                "name": "{prefix}Heating constant temperature 3"
-            },
-            "heiz_konstanttemp4": {
-                "name": "{prefix}Heating constant temperature 4"
-            },
-            "heiz_konstanttemp5": {
-                "name": "{prefix}Heating constant temperature 5"
-            },
-            "heiz_konstanttemp_absenk": {
-                "name": "{prefix}Heating constant temp. lowering"
-            },
-            "heiz_konstanttemp_absenk2": {
-                "name": "{prefix}Heating constant temp. lowering2"
-            },
-            "heiz_konstanttemp_absenk3": {
-                "name": "{prefix}Heating constant temp. lowering3"
-            },
-            "heiz_konstanttemp_absenk4": {
-                "name": "{prefix}Heating constant temp. lowering4"
-            },
-            "heiz_konstanttemp_absenk5": {
-                "name": "{prefix}Heating constant temp. lowering5"
-            },
-            "hz_konf": {
-                "name": "{prefix}Heating circuit configuration",
-                "state": {
-                    "hp_konf_aus": "off",
-                    "hp_konf_mischkreis": "Mixing circuit",
-                    "hp_konf_pumpenkreis": "Pump circuit",
-                    "hp_konf_sollwert_pumpe_m1": "Setpoint (pump M1)"
-                }
-            },
-            "hz_konf2": {
-                "name": "{prefix}Heating circuit configuration 2",
-                "state": {
-                    "hp_konf_aus": "off",
-                    "hp_konf_mischkreis": "Mixing circuit",
-                    "hp_konf_pumpenkreis": "Pump circuit",
-                    "hp_konf_sollwert_pumpe_m1": "Setpoint (pump M1)"
-                }
-            },
-            "hz_konf3": {
-                "name": "{prefix}Heating circuit configuration 3",
-                "state": {
-                    "hp_konf_aus": "off",
-                    "hp_konf_mischkreis": "Mixing circuit",
-                    "hp_konf_pumpenkreis": "Pump circuit",
-                    "hp_konf_sollwert_pumpe_m1": "Setpoint (pump M1)"
-                }
-            },
-            "hz_konf4": {
-                "name": "{prefix}Heating circuit configuration 4",
-                "state": {
-                    "hp_konf_aus": "off",
-                    "hp_konf_mischkreis": "Mixing circuit",
-                    "hp_konf_pumpenkreis": "Pump circuit",
-                    "hp_konf_sollwert_pumpe_m1": "Setpoint (pump M1)"
-                }
-            },
-            "hz_konf5": {
-                "name": "{prefix}Heating circuit configuration 5",
-                "state": {
-                    "hp_konf_aus": "off",
-                    "hp_konf_mischkreis": "Mixing circuit",
-                    "hp_konf_pumpenkreis": "Pump circuit",
-                    "hp_konf_sollwert_pumpe_m1": "Setpoint (pump M1)"
-                }
-            },
-            "hz_vl_temp": {
-                "name": "{prefix}Heat circuit feed temperature"
-            },
-            "hz_vl_temp2": {
-                "name": "{prefix}Heat circuit feed temperature 2"
-            },
-            "hz_vl_temp3": {
-                "name": "{prefix}Heat circuit feed temperature 3"
-            },
-            "hz_vl_temp4": {
-                "name": "{prefix}Heat circuit feed temperature 4"
-            },
-            "hz_vl_temp5": {
-                "name": "{prefix}Heat circuit feed temperature 5"
-            },
-            "hz_vl_solltemp": {
-                "name": "{prefix}Heat circuit feed setpoint temperature"
-            },
-            "hz_vl_solltemp2": {
-                "name": "{prefix}Heat circuit feed setpoint temperature2"
-            },
-            "hz_vl_solltemp3": {
-                "name": "{prefix}Heat circuit feed setpoint temperature3"
-            },
-            "hz_vl_solltemp4": {
-                "name": "{prefix}Heat circuit feed setpoint temperature4"
-            },
-            "hz_vl_solltemp5": {
-                "name": "{prefix}Heat circuit feed setpoint temperature5"
-            },
-            "konf_ausg_h12": {
-                "name": "{prefix}Conf. Output H1.2",
-                "state": {
-                    "io_konf_0": "0",
-                    "io_konf_1": "1",
-                    "io_konf_2": "2",
-                    "io_konf_3": "3",
-                    "io_konf_4": "4",
-                    "io_konf_5": "5",
-                    "io_konf_6": "6",
-                    "io_konf_65535": "65535",
-                    "io_konf_7": "7"
-                }
-            },
-            "konf_ausg_h13": {
-                "name": "{prefix}Conf. Output  H1.3",
-                "state": {
-                    "io_konf_0": "0",
-                    "io_konf_1": "1",
-                    "io_konf_2": "2",
-                    "io_konf_3": "3",
-                    "io_konf_4": "4",
-                    "io_konf_5": "5",
-                    "io_konf_6": "6",
-                    "io_konf_65535": "65535",
-                    "io_konf_7": "7"
-                }
-            },
-            "konf_ausg_h14": {
-                "name": "{prefix}Conf. Output  H1.4",
-                "state": {
-                    "io_konf_0": "0",
-                    "io_konf_1": "1",
-                    "io_konf_2": "2",
-                    "io_konf_3": "3",
-                    "io_konf_4": "4",
-                    "io_konf_5": "5",
-                    "io_konf_6": "6",
-                    "io_konf_65535": "65535",
-                    "io_konf_7": "7"
-                }
-            },
-            "konf_ausg_h15": {
-                "name": "{prefix}Conf. Output  H1.5",
-                "state": {
-                    "io_konf_0": "0",
-                    "io_konf_1": "1",
-                    "io_konf_2": "2",
-                    "io_konf_3": "3",
-                    "io_konf_4": "4",
-                    "io_konf_5": "5",
-                    "io_konf_6": "6",
-                    "io_konf_65535": "65535",
-                    "io_konf_7": "7"
-                }
-            },
-            "konf_eing_de1": {
-                "name": "{prefix}Conf. Input DE1",
-                "state": {
-                    "io_konf_in_0": "SG Ready",
-                    "io_konf_in_1": "EVU block",
-                    "io_konf_in_10": "Producer block HZ and WW",
-                    "io_konf_in_11": "Hot water standby",
-                    "io_konf_in_12": "Hot water lowering",
-                    "io_konf_in_13": "Hot water normal",
-                    "io_konf_in_14": "Hot water PUSH",
-                    "io_konf_in_15": "Dew point monitor",
-                    "io_konf_in_16": "Heating circuit ... Standby",
-                    "io_konf_in_17": "Heating circuit ... lowering",
-                    "io_konf_in_18": "Heating circuit ... normal",
-                    "io_konf_in_19": "Heating circuit ... comfort",
-                    "io_konf_in_2": "Increased operation",
-                    "io_konf_in_20": "2nd heat source",
-                    "io_konf_in_21": "Lock compressor",
-                    "io_konf_in_3": "HK block",
-                    "io_konf_in_4": "Hz/cooling changeover",
-                    "io_konf_in_5": "Sleep mode",
-                    "io_konf_in_6": "Emergency stop",
-                    "io_konf_in_65535": "OFF",
-                    "io_konf_in_7": "System standby",
-                    "io_konf_in_8": "Producer lock HZ",
-                    "io_konf_in_9": "Producer block WW"
-                }
-            },
-            "konf_eing_de2": {
-                "name": "{prefix}Conf. Input DE2",
-                "state": {
-                    "io_konf_in_0": "SG Ready",
-                    "io_konf_in_1": "EVU block",
-                    "io_konf_in_10": "Producer block HZ and WW",
-                    "io_konf_in_11": "Hot water standby",
-                    "io_konf_in_12": "Hot water lowering",
-                    "io_konf_in_13": "Hot water normal",
-                    "io_konf_in_14": "Hot water PUSH",
-                    "io_konf_in_15": "Dew point monitor",
-                    "io_konf_in_16": "Heating circuit ... Standby",
-                    "io_konf_in_17": "Heating circuit ... lowering",
-                    "io_konf_in_18": "Heating circuit ... normal",
-                    "io_konf_in_19": "Heating circuit ... comfort",
-                    "io_konf_in_2": "Increased operation",
-                    "io_konf_in_20": "2nd heat source",
-                    "io_konf_in_21": "Lock compressor",
-                    "io_konf_in_3": "HK block",
-                    "io_konf_in_4": "Hz/cooling changeover",
-                    "io_konf_in_5": "Sleep mode",
-                    "io_konf_in_6": "Emergency stop",
-                    "io_konf_in_65535": "OFF",
-                    "io_konf_in_7": "System standby",
-                    "io_konf_in_8": "Producer lock HZ",
-                    "io_konf_in_9": "Producer block WW"
-                }
-            },
-            "konf_eing_sgr1": {
-                "name": "{prefix}Conf. Input SGR1",
-                "state": {
-                    "io_konf_in_0": "SG Ready",
-                    "io_konf_in_1": "EVU block",
-                    "io_konf_in_10": "Producer block HZ and WW",
-                    "io_konf_in_11": "Hot water standby",
-                    "io_konf_in_12": "Hot water lowering",
-                    "io_konf_in_13": "Hot water normal",
-                    "io_konf_in_14": "Hot water PUSH",
-                    "io_konf_in_15": "Dew point monitor",
-                    "io_konf_in_16": "Heating circuit ... Standby",
-                    "io_konf_in_17": "Heating circuit ... lowering",
-                    "io_konf_in_18": "Heating circuit ... normal",
-                    "io_konf_in_19": "Heating circuit ... comfort",
-                    "io_konf_in_2": "Increased operation",
-                    "io_konf_in_20": "2nd heat source",
-                    "io_konf_in_21": "Lock compressor",
-                    "io_konf_in_3": "HK block",
-                    "io_konf_in_4": "Hz/cooling changeover",
-                    "io_konf_in_5": "Sleep mode",
-                    "io_konf_in_6": "Emergency stop",
-                    "io_konf_in_65535": "OFF",
-                    "io_konf_in_7": "System standby",
-                    "io_konf_in_8": "Producer lock HZ",
-                    "io_konf_in_9": "Producer block WW"
-                }
-            },
-            "konf_eing_sgr2": {
-                "name": "{prefix}Conf. Input SGR2",
-                "state": {
-                    "io_konf_in_0": "SG Ready",
-                    "io_konf_in_1": "EVU block",
-                    "io_konf_in_10": "Producer block HZ and WW",
-                    "io_konf_in_11": "Hot water standby",
-                    "io_konf_in_12": "Hot water lowering",
-                    "io_konf_in_13": "Hot water normal",
-                    "io_konf_in_14": "Hot water PUSH",
-                    "io_konf_in_15": "Dew point monitor",
-                    "io_konf_in_16": "Heating circuit ... Standby",
-                    "io_konf_in_17": "Heating circuit ... lowering",
-                    "io_konf_in_18": "Heating circuit ... normal",
-                    "io_konf_in_19": "Heating circuit ... comfort",
-                    "io_konf_in_2": "Increased operation",
-                    "io_konf_in_20": "2nd heat source",
-                    "io_konf_in_21": "Lock compressor",
-                    "io_konf_in_3": "HK block",
-                    "io_konf_in_4": "Hz/cooling changeover",
-                    "io_konf_in_5": "Sleep mode",
-                    "io_konf_in_6": "Emergency stop",
-                    "io_konf_in_65535": "OFF",
-                    "io_konf_in_7": "System standby",
-                    "io_konf_in_8": "Producer lock HZ",
-                    "io_konf_in_9": "Producer block WW"
-                }
-            },
-            "kuehl_energie_yesterday": {
-                "name": "{prefix}Cooling energy yesterday"
-            },
-            "kuehl_energie_heute": {
-                "name": "{prefix}Cooling energy heute"
-            },
-            "kuehl_energie_jahr": {
-                "name": "{prefix}Cooling energy year"
-            },
-            "kuehl_energie_monat": {
-                "name": "{prefix}Cooling energy month"
-            },
-            "kuehl_konstanttemp": {
-                "name": "{prefix}Cooling constant temperature"
-            },
-            "kuehl_konstanttemp2": {
-                "name": "{prefix}Cooling constant temperature 2"
-            },
-            "kuehl_konstanttemp3": {
-                "name": "{prefix}Cooling constant temperature 3"
-            },
-            "kuehl_konstanttemp4": {
-                "name": "{prefix}Cooling constant temperature 4"
-            },
-            "kuehl_konstanttemp5": {
-                "name": "{prefix}Cooling constant temperature 5"
-            },
-            "leistungsanforderung": {
-                "name": "{prefix}Power request"
-            },
-            "luftansautgemp": {
-                "name": "{prefix}Air intake temperature"
-            },
-            "puffer_temp": {
-                "name": "{prefix}Buffer temperature"
-            },
-            "pumpe_einschaltart": {
-                "name": "{prefix}Pump operation mode"
-            },
-            "raum_feuchte": {
-                "name": "{prefix}Room humidity"
-            },
-            "raum_feuchte2": {
-                "name": "{prefix}Room humidity 2"
-            },
-            "raum_feuchte3": {
-                "name": "{prefix}Room humidity 3"
-            },
-            "raum_feuchte4": {
-                "name": "{prefix}Room humidity 4"
-            },
-            "raum_feuchte5": {
-                "name": "{prefix}Room humidity 5"
-            },
-            "raum_soll_temp": {
-                "name": "{prefix}Room setpoint temperature"
-            },
-            "raum_soll_temp2": {
-                "name": "{prefix}Room setpoint temperature 2"
-            },
-            "raum_soll_temp3": {
-                "name": "{prefix}Room setpoint temperature 3"
-            },
-            "raum_soll_temp4": {
-                "name": "{prefix}Room setpoint temperature 4"
-            },
-            "raum_soll_temp5": {
-                "name": "{prefix}Room setpoint temperature 5"
-            },
-            "raum_temp": {
-                "name": "{prefix}Room temperature"
-            },
-            "raum_temp2": {
-                "name": "{prefix}Room temperature 2"
-            },
-            "raum_temp3": {
-                "name": "{prefix}Room temperature 3"
-            },
-            "raum_temp4": {
-                "name": "{prefix}Room temperature 4"
-            },
-            "raum_temp5": {
-                "name": "{prefix}Room temperature 5"
-            },
-            "rl_temp": {
-                "name": "{prefix}Return flow temperature"
-            },
-            "ruhemodus": {
-                "name": "{prefix}Silent mode",
-                "state": {
-                    "hp_ruhemodus_0": "off",
-                    "hp_ruhemodus_1": "80 %",
-                    "hp_ruhemodus_2": "60 %",
-                    "hp_ruhemodus_3": "40 %"
-                }
-            },
-            "schaltsp_e1": {
-                "name": "{prefix}Switching cycles E-heating 1"
-            },
-            "schaltsp_e2": {
-                "name": "{prefix}Switching cycles E-heating 2"
-            },
-            "sgr1": {
-                "name": "{prefix}SG-Ready 1"
-            },
-            "sgr2": {
-                "name": "{prefix}SG-Ready 2"
-            },
-            "soll_volumenstrom_heizen": {
-                "name": "{prefix}Setpoint volume flow Heating"
-            },
-            "soll_volumenstrom_kuehlen": {
-                "name": "{prefix}Setpoint volume flow Cooling"
-            },
-            "soll_volumenstrom_ww": {
-                "name": "{prefix}Setpoint volume flow Hot water"
-            },
-            "sollwert_pumpe_leistung_abtau": {
-                "name": "{prefix}Setpoint pump power defrost"
-            },
-            "sollwert_pumpe_leistung_heizen": {
-                "name": "{prefix}Setpoint pump power Heating"
-            },
-            "sollwert_pumpe_leistung_kuehlen": {
-                "name": "{prefix}Setpoint pump power Cooling"
-            },
-            "sollwert_pumpe_leitung_ww": {
-                "name": "{prefix}Setpoint pump power Hot water"
-            },
-            "status_2_wez": {
-                "name": "{prefix}Status 2nd heat source",
-                "state": {
-                    "w2_status_aus": "off",
-                    "w2_status_ein": "on"
-                }
-            },
-            "status_e1": {
-                "name": "{prefix}Status E-Heater 1",
-                "state": {
-                    "w2_status_aus": "off",
-                    "w2_status_ein": "on"
-                }
-            },
-            "status_e2": {
-                "name": "{prefix}Status E-Heater 2",
-                "state": {
-                    "w2_status_aus": "off",
-                    "w2_status_ein": "on"
-                }
-            },
-            "verdampfungs_temp": {
-                "name": "{prefix}Evaporation temperature"
-            },
-            "verdichter_ansaug_gas_temp": {
-                "name": "{prefix}Compressor suction gas temp"
-            },
-            "vl_praeziese_summenvorlauf_b7": {
-                "name": "{prefix}Feed temperature präzise(Summenvorlauf(B7))"
-            },
-            "vl_temp": {
-                "name": "{prefix}Feed temperature"
-            },
-            "w2_konf": {
-                "name": "{prefix}W2_Configuration",
-                "state": {
-                    "w2_konf_0": "0",
-                    "w2_konf_1": "1"
-                }
-            },
-            "waermeleistung": {
-                "name": "{prefix}Heating power"
-            },
-            "warnung": {
-                "name": "{prefix}Warning",
-                "state": {
-                    "sys_fehler_1": "Refrigerant sensor expansion valve inlet (T1)",
-                    "sys_fehler_10": "High pressure sensor (P2)",
-                    "sys_fehler_101": "Heat pump is being operated outside the operating limits",
-                    "sys_fehler_102": "Maximum defrost time exceeded",
-                    "sys_fehler_103": "Communication refrigeration circuit faulty",
-                    "sys_fehler_104": "discharge gas temperature too high",
-                    "sys_fehler_105": "Current consumption from inverter too high",
-                    "sys_fehler_106": "Current consumption too high",
-                    "sys_fehler_107": "DC voltage on inverter too high",
-                    "sys_fehler_108": "DC voltage on inverter too low",
-                    "sys_fehler_109": "Heat pump is operated outside the permissible voltage range",
-                    "sys_fehler_11": "Medium pressure sensor (P3)",
-                    "sys_fehler_110": "Heat pump is being operated outside the permissible voltage range",
-                    "sys_fehler_111": "High pressure switch has triggered",
-                    "sys_fehler_112": "Inverter has overheated",
-                    "sys_fehler_113": "Inverter has overheated",
-                    "sys_fehler_114": "Position of compressor motor cannot be determined",
-                    "sys_fehler_117": "DC voltage on inverter too low",
-                    "sys_fehler_118": "Current between inverter and compressor is too high",
-                    "sys_fehler_119": "Current consumption from compressor too high Timeout",
-                    "sys_fehler_12": "Cooling expansion valve defective",
-                    "sys_fehler_120": "Inverter temperature too high",
-                    "sys_fehler_121": "Voltage on inverter too low",
-                    "sys_fehler_122": "Modbus configuration error",
-                    "sys_fehler_123": "No Modbus connection",
-                    "sys_fehler_124": "discharge gas temperature too high",
-                    "sys_fehler_127": "Inverter temperature too high",
-                    "sys_fehler_128": "Inverter is overheated",
-                    "sys_fehler_129": "Modbus communication faulty",
-                    "sys_fehler_13": "No communication to the inverter",
-                    "sys_fehler_130": "Modbus communication faulty",
-                    "sys_fehler_133": "Electronics error",
-                    "sys_fehler_135": "High pressure switch defective",
-                    "sys_fehler_136": "Compressor does not match configuration",
-                    "sys_fehler_137": "High pressure switch does not match the configuration",
-                    "sys_fehler_14": "No communication with the outdoor unit",
-                    "sys_fehler_140": "discharge gas temperature too low",
-                    "sys_fehler_143": "Inverter temperature too low",
-                    "sys_fehler_144": "Choke coil temperature too low",
-                    "sys_fehler_15": "High pressure switch has triggered",
-                    "sys_fehler_150": "Compressor current sensor phase U error",
-                    "sys_fehler_151": "Compressor current sensor phase V error",
-                    "sys_fehler_152": "Compressor current sensor phase W error voltage supply from input terminal",
-                    "sys_fehler_153": "Current sensor error",
-                    "sys_fehler_154": "Inverter temperature sensor error",
-                    "sys_fehler_155": "Temperature sensor error",
-                    "sys_fehler_156": "Compressed gas sensor (DT)",
-                    "sys_fehler_157": "No communication to the cooling unit control board",
-                    "sys_fehler_158": "EEPROM memory error",
-                    "sys_fehler_159": "Current consumption too high",
-                    "sys_fehler_16": "Inverter disabled because 10 errors have occurred in the last 10 hours",
-                    "sys_fehler_160": "Heat pump is being operated outside the permissible voltage range",
-                    "sys_fehler_161": "Heat pump is being operated outside the permissible voltage range",
-                    "sys_fehler_162": "DC voltage on inverter too high",
-                    "sys_fehler_163": "DC voltage on inverter too low",
-                    "sys_fehler_164": "High pressure switch has triggered",
-                    "sys_fehler_165": "Phase between input and compressor interrupted",
-                    "sys_fehler_166": "Inverter overheated",
-                    "sys_fehler_167": "Inverter overheated",
-                    "sys_fehler_168": "Compressor configuration error",
-                    "sys_fehler_169": "Compressor current consumption too high",
-                    "sys_fehler_17": "EEPROM memory error",
-                    "sys_fehler_170": "Compressor phase U overvoltage",
-                    "sys_fehler_171": "Compressor phase V overvoltage",
-                    "sys_fehler_172": "Compressor phase W overvoltage",
-                    "sys_fehler_173": "Compressor phase failure",
-                    "sys_fehler_174": "Compressor blocked",
-                    "sys_fehler_175": "Compressor does not start",
-                    "sys_fehler_176": "Irregular voltage supply from inverter",
-                    "sys_fehler_177": "Compressor overloaded",
-                    "sys_fehler_178": "Temperature at discharge gas sensor (DT) too high",
-                    "sys_fehler_179": "Temperature at inverter",
-                    "sys_fehler_18": "No Modbus communication between EC controller and refrigeration unit control board",
-                    "sys_fehler_180": "Compressor blocked",
-                    "sys_fehler_181": "Compressor blocked",
-                    "sys_fehler_182": "Current consumption too high",
-                    "sys_fehler_183": "Current consumption too high",
-                    "sys_fehler_184": "Voltage too high",
-                    "sys_fehler_19": "Heat pump switched off by inverter alarm",
-                    "sys_fehler_2": "Air intake sensor (T2)",
-                    "sys_fehler_20": "Compressor does not match the configuration",
-                    "sys_fehler_21": "Low pressure fault",
-                    "sys_fehler_22": "Insufficient superheat",
-                    "sys_fehler_23": "excessive superheat",
-                    "sys_fehler_24": "EVI too high overheating",
-                    "sys_fehler_25": "Refrigerant quantity too low",
-                    "sys_fehler_26": "High pressure fault",
-                    "sys_fehler_27": "Condensation temperature too low",
-                    "sys_fehler_28": "Condensation temperature too high",
-                    "sys_fehler_29": "Evaporation temperature too low",
-                    "sys_fehler_3": "Heat exchanger sensor AG outlet (T3)",
-                    "sys_fehler_30": "Evaporation temperature too high",
-                    "sys_fehler_32": "Heat pump not compatible",
-                    "sys_fehler_33": "Controller EC has no connection to expansion module EM-HK",
-                    "sys_fehler_4": "Compressor suction gas sensor (T4)",
-                    "sys_fehler_40": "Volume flow too low",
-                    "sys_fehler_41": "Spreizung LWT/Rücklauf negative / four-way valve does not switch back after defrosting; the system locks after 3 warnings)",
-                    "sys_fehler_43": "Fan blocked",
-                    "sys_fehler_44": "Fan speed too low",
-                    "sys_fehler_47": "Communication controller EC to control board refrigeration unit faulty",
-                    "sys_fehler_5": "EVI suction gas sensor (T5)",
-                    "sys_fehler_50": "Outdoor sensor (B1) interrupted",
-                    "sys_fehler_51": "Outdoor sensor (B1) short-circuited",
-                    "sys_fehler_52": "Point sensor (B2) interrupted",
-                    "sys_fehler_53": "Point sensor (B2) short-circuited",
-                    "sys_fehler_54": "Hot water sensor (B3) interrupted",
-                    "sys_fehler_55": "Hot water sensor (B3) short-circuited",
-                    "sys_fehler_56": "Condenser flow sensor (B4) interrupted",
-                    "sys_fehler_57": "Condenser flow sensor (B4) short-circuited",
-                    "sys_fehler_58": "Flow sensor (B7) interrupted",
-                    "sys_fehler_59": "Flow sensor (B7) short-circuited",
-                    "sys_fehler_6": "Refrigerant sensor IG outlet (T6)",
-                    "sys_fehler_60": "Return flow sensor (B9) interrupted",
-                    "sys_fehler_61": "Return flow sensor (B9) short-circuited",
-                    "sys_fehler_64": "Buffer sensor (B11) interrupted",
-                    "sys_fehler_65": "Buffer sensor (B11) short-circuited",
-                    "sys_fehler_65535": "no error",
-                    "sys_fehler_66": "Regenerative mixer sensor (B2.1) interrupted",
-                    "sys_fehler_67": "Regenerative mixer sensor (B2.1) short-circuited",
-                    "sys_fehler_7": "Oil sump sensor (T7)",
-                    "sys_fehler_70": "Second heating circuit flow sensor (B6.2) interrupted",
-                    "sys_fehler_71": "Second heating circuit flow sensor (B6.2) short-circuited",
-                    "sys_fehler_72": "Sensor (T1.2) interrupted",
-                    "sys_fehler_73": "Sensor (T1.2) short-circuited",
-                    "sys_fehler_74": "Sensor (T2.2) interrupted",
-                    "sys_fehler_75": "Sensor (T2.2) short-circuited",
-                    "sys_fehler_8": "Expansion valve EVI",
-                    "sys_fehler_9": "Low pressure sensor (P1)",
-                    "sys_fehler_90": "Analog input AE1 interrupted",
-                    "sys_fehler_91": "Analog input AE1 short-circuited",
-                    "sys_fehler_92": "Analog input AE2 interrupted",
-                    "sys_fehler_93": "Analog input AE2 short-circuited",
-                    "sys_fehler_94": "Analog input AE3 interrupted",
-                    "sys_fehler_95": "Analog input AE3 short-circuited"
-                }
-            },
-            "weichen_temp": {
-                "name": "{prefix}Switch temperature"
-            },
-            "wp_betrieb": {
-                "name": "{prefix}Operation",
-                "state": {
-                    "heatpump_operationmode_undefined": "Undefined",
-                    "heatpump_operationmode_relaistest": "Relay test",
-                    "heatpump_operationmode_evu": "EVU_SPERRE",
-                    "heatpump_operationmode_sgtariff": "SG tariff",
-                    "heatpump_operationmode_sgmax": "SG Maximum",
-                    "heatpump_operationmode_tariffload": "Tariff load",
-                    "heatpump_operationmode_elevatedoperation": "Increased operation",
-                    "heatpump_operationmode_standbytime": "Standstill time",
-                    "heatpump_operationmode_standby": "Standby mode",
-                    "heatpump_operationmode_rinse": "Rinsing mode",
-                    "heatpump_operationmode_frosprotection": "Frost protection",
-                    "heatpump_operationmode_heating": "Heating mode",
-                    "heatpump_operationmode_emergencystop": "Emergency stop",
-                    "heatpump_operationmode_hotwater": "Hot water mode",
-                    "heatpump_operationmode_legionellaprotection": "Legionella protection",
-                    "heatpump_operationmode_switchheatingcooling": "Switchover HZ KU",
-                    "heatpump_operationmode_cooling": "Cooling mode",
-                    "heatpump_operationmode_passivecooling": "Passive cooling",
-                    "heatpump_operationmode_summer": "Summer mode",
-                    "heatpump_operationmode_swimmingpool": "Swimming pool",
-                    "heatpump_operationmode_vacation": "Vacation",
-                    "heatpump_operationmode_screedprogram": "Screed",
-                    "heatpump_operationmode_locked": "Locked",
-                    "heatpump_operationmode_diagnosis": "Diagnosis",
-                    "heatpump_operationmode_lockedat": "Lock AT",
-                    "hp_bheatpump_operationmode_lockedsummeretrieb_31": "Lock summer",
-                    "heatpump_operationmode_lockedwinter": "Winter lock",
-                    "heatpump_operationmode_applicationlimit": "Application limit",
-                    "heatpump_operationmode_lockedcv": "HK lock",
-                    "heatpump_operationmode_lowering": "lowering",
-                    "heatpump_operationmode_manual": "Manual mode",
-                    "heatpump_operationmode_oilrecirculation": "Oil return",
-                    "heatpump_operationmode_manualheating": "Manual mode heating",
-                    "heatpump_operationmode_manualcooling": "Manual mode cooling",
-                    "heatpump_operationmode_manualdefrost": "Manual defrosting mode",
-                    "heatpump_operationmode_defrost": "Defrost",
-                    "heatpump_operationmode_manual2ndheatsource": "2nd heat source"
-                }
-            },
-            "wp_konf": {
-                "name": "{prefix}Configuration",
-                "state": {
-                    "hp_conf_1": "Heating",
-                    "hp_conf_2": "Heating, Cooling",
-                    "hp_conf_3": "Heating, Cooling",
-                    "hp_conf_4": "Heating, Hot water",
-                    "hp_konf_0": "not configured"
-                }
-            },
-            "wp_stoermeldung": {
-                "name": "{prefix}Error message",
-                "state": {
-                    "hp_stoerung": "error",
-                    "hp_stoerungsfrei": "no error"
-                }
-            },
-            "tagesarbeitszahl_heute": {
-                "name": "{prefix}Daily performance factor today"
-            },
-            "spreizung": {
-                "name": "{prefix}Spread"
-            },
-            "jahresarbeitszahl": {
-                "name": "{prefix}Annual performance factor"
-            },
-            "tagesarbeitszahl_gestern": {
-                "name": "{prefix}Daily performance factor yesterday"
-            },
-            "monatsarbeitszahl": {
-                "name": "{prefix}Monthly performance factor"
-            },
-            "ww_energie_yesterday": {
-                "name": "{prefix}Hot water energy yesterday"
-            },
-            "ww_energie_heute": {
-                "name": "{prefix}Hot water energy heute"
-            },
-            "ww_energie_jahr": {
-                "name": "{prefix}Hot water energy year"
-            },
-            "ww_energie_monat": {
-                "name": "{prefix}Hot water energy month"
-            },
-            "ww_konf": {
-                "name": "{prefix}HW_Configuration",
-                "state": {
-                    "ww_konf_aus": "off",
-                    "ww_konf_pumpe": "Pump",
-                    "ww_konf_umlenkventil": "Diverting valve"
-                }
-            },
-            "ww_soll_temp": {
-                "name": "{prefix}Hot water setpoint temperature"
-            },
-            "ww_temp": {
-                "name": "{prefix}Hot water temperature"
-            }
+    "step": {
+      "user": {
+        "data": {
+          "Device-Postfix": "Device postfix",
+          "Heizkreis 2": "2nd heating circuit",
+          "Heizkreis 3": "3rd heating circuit",
+          "Heizkreis 4": "4th heating circuit",
+          "Heizkreis 5": "5th heating circuit",
+          "Host": "Host!",
+          "Kennfeld-File": "Filename Kennfeld",
+          "Name-Device-Prefix": "Name Device Prefix",
+          "Name-Topic-Prefix": "Name Topic Prefix",
+          "Port": "Port",
+          "Prefix": "Prefix",
+          "enable-webif": "enable experimental webif?",
+          "Web-IF-Token": "four letter web-IF token, see readme"
         }
+      }
+    }
+  },
+  "device": {
+    "dev_ein_aus": {
+      "name": "WH Input/output{postfix}"
     },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "api_scan_interval": "Api scan interval (default = 300 sec)",
-                    "language": "Language (default = en)",
-                    "mode": "Mode(default = api)",
-                    "scan_interval": "Web scraping interval (default = 1800 sec)"
-                }
-            }
+    "dev_heizkreis": {
+      "name": "WH Heating circuit{postfix}"
+    },
+    "dev_heizkreis2": {
+      "name": "WH Heating circuit2{postfix}"
+    },
+    "dev_heizkreis3": {
+      "name": "WH Heating circuit3{postfix}"
+    },
+    "dev_heizkreis4": {
+      "name": "WH Heating circuit4{postfix}"
+    },
+    "dev_heizkreis5": {
+      "name": "WH Heating circuit5{postfix}"
+    },
+    "dev_statistik": {
+      "name": "WH Statistics{postfix}"
+    },
+    "dev_system": {
+      "name": "WH System{postfix}"
+    },
+    "dev_unknown": {
+      "name": "WH Unknown{postfix}"
+    },
+    "dev_waermeerzeuger2": {
+      "name": "WH 2nd heat source{postfix}"
+    },
+    "dev_waermepumpe": {
+      "name": "WH Heat pump{postfix}"
+    },
+    "dev_warmwasser": {
+      "name": "WH Hot water{postfix}"
+    }
+  },
+  "entity": {
+    "number": {
+      "bivalenztemp": {
+        "name": "{prefix}Bivalence temperature"
+      },
+      "bivalenztemp_ww": {
+        "name": "{prefix}Bivalence temperature HW"
+      },
+      "grenztemp": {
+        "name": "{prefix}Limit temperature"
+      },
+      "heizkennlinie": {
+        "name": "{prefix}Heating curve"
+      },
+      "heizkennlinie2": {
+        "name": "{prefix}Heating curve2"
+      },
+      "heizkennlinie3": {
+        "name": "{prefix}Heating curve3"
+      },
+      "heizkennlinie4": {
+        "name": "{prefix}Heating curve4"
+      },
+      "heizkennlinie5": {
+        "name": "{prefix}Heating curve5"
+      },
+      "raum_soll_temp_absenk": {
+        "name": "{prefix}Room setpoint temperature lowering"
+      },
+      "raum_soll_temp_absenk2": {
+        "name": "{prefix}Room setpoint temperature lowering2"
+      },
+      "raum_soll_temp_absenk3": {
+        "name": "{prefix}Room setpoint temperature lowering3"
+      },
+      "raum_soll_temp_absenk4": {
+        "name": "{prefix}Room setpoint temperature lowering4"
+      },
+      "raum_soll_temp_absenk5": {
+        "name": "{prefix}Room setpoint temperature lowering5"
+      },
+      "raum_soll_temp_komf": {
+        "name": "{prefix}Room setpoint temperature comfort"
+      },
+      "raum_soll_temp_komf2": {
+        "name": "{prefix}Room setpoint temperature comfort2"
+      },
+      "raum_soll_temp_komf3": {
+        "name": "{prefix}Room setpoint temperature comfort3"
+      },
+      "raum_soll_temp_komf4": {
+        "name": "{prefix}Room setpoint temperature comfort4"
+      },
+      "raum_soll_temp_komf5": {
+        "name": "{prefix}Room setpoint temperature comfort5"
+      },
+      "raum_soll_temp_normal": {
+        "name": "{prefix}Room setpoint temperature normal"
+      },
+      "raum_soll_temp_normal2": {
+        "name": "{prefix}Room setpoint temperature normal2"
+      },
+      "raum_soll_temp_normal3": {
+        "name": "{prefix}Room setpoint temperature normal3"
+      },
+      "raum_soll_temp_normal4": {
+        "name": "{prefix}Room setpoint temperature normal4"
+      },
+      "raum_soll_temp_normal5": {
+        "name": "{prefix}Room setpoint temperature normal5"
+      },
+      "sgr_anhebung": {
+        "name": "{prefix}SG Ready increase"
+      },
+      "so_wi_umschalt": {
+        "name": "{prefix}Summer winter changeover"
+      },
+      "so_wi_umschalt2": {
+        "name": "{prefix}Summer winter changeover2"
+      },
+      "so_wi_umschalt3": {
+        "name": "{prefix}Summer winter changeover3"
+      },
+      "so_wi_umschalt4": {
+        "name": "{prefix}Summer winter changeover4"
+      },
+      "so_wi_umschalt5": {
+        "name": "{prefix}Summer winter changeover5"
+      },
+      "ww_absenk": {
+        "name": "{prefix}Hot water lowering"
+      },
+      "ww_normal": {
+        "name": "{prefix}Hot water normal"
+      }
+    },
+    "select": {
+      "hz_operationmode": {
+        "name": "{prefix}Operation mode",
+        "state": {
+          "hz_operationmode_lowering": "Lowering mode",
+          "hz_operationmode_automatic": "Automatic",
+          "hz_operationmode_normal": "Normal",
+          "hz_operationmode_standby": "Standby",
+          "hz_operationmode_comfort": "Comfort"
         }
+      },
+      "hz_operationmode2": {
+        "name": "{prefix}Operation mode2",
+        "state": {
+          "hz_operationmode_lowering": "Lowering mode",
+          "hz_operationmode_automatic": "Automatic",
+          "hz_operationmode_normal": "Normal",
+          "hz_operationmode_standby": "Standby",
+          "hz_operationmode_comfort": "Comfort"
+        }
+      },
+      "hz_operationmode3": {
+        "name": "{prefix}Operation mode3",
+        "state": {
+          "hz_operationmode_lowering": "Lowering mode",
+          "hz_operationmode_automatic": "Automatic",
+          "hz_operationmode_normal": "Normal",
+          "hz_operationmode_standby": "Standby",
+          "hz_operationmode_comfort": "Comfort"
+        }
+      },
+      "hz_operationmode4": {
+        "name": "{prefix}Operation mode4",
+        "state": {
+          "hz_operationmode_lowering": "Lowering mode",
+          "hz_operationmode_automatic": "Automatic",
+          "hz_operationmode_normal": "Normal",
+          "hz_operationmode_standby": "Standby",
+          "hz_operationmode_comfort": "Comfort"
+        }
+      },
+      "hz_operationmode5": {
+        "name": "{prefix}Operation mode5",
+        "state": {
+          "hz_operationmode_lowering": "Lowering mode",
+          "hz_operationmode_automatic": "Automatic",
+          "hz_operationmode_normal": "Normal",
+          "hz_operationmode_standby": "Standby",
+          "hz_operationmode_comfort": "Comfort"
+        }
+      },
+      "party_pause": {
+        "name": "{prefix}Pause / Party",
+        "state": {
+          "hz_party_0_5": "Party 0.5h",
+          "hz_party_1": "Party 1.0h",
+          "hz_party_10": "Party 10.0h",
+          "hz_party_10_5": "Party 10.5h",
+          "hz_party_11": "Party 11.0h",
+          "hz_party_11_5": "Party 11.5h",
+          "hz_party_12": "Party 12.0h",
+          "hz_party_1_5": "Party 1.5h",
+          "hz_party_2": "Party 2.0h",
+          "hz_party_2_5": "Party 2.5h",
+          "hz_party_3": "Party 3.0h",
+          "hz_party_3_5": "Party 3.5h",
+          "hz_party_4": "Party 4.0h",
+          "hz_party_4_5": "Party 4.5h",
+          "hz_party_5": "Party 5.0h",
+          "hz_party_5_5": "Party 5.5h",
+          "hz_party_6": "Party 6.0h",
+          "hz_party_6_5": "Party 6.5h",
+          "hz_party_7": "Party 7.0h",
+          "hz_party_7_5": "Party 7.5h",
+          "hz_party_8": "Party 8.0h",
+          "hz_party_8_5": "Party 8.5h",
+          "hz_party_9": "Party 9.0h",
+          "hz_party_9_5": "Party 9.5h",
+          "hz_party_pause_auto": "Automatic",
+          "hz_pause_0_5": "Pause 0.5h",
+          "hz_pause_1": "Pause 1.0h",
+          "hz_pause_10": "Pause 10.0h",
+          "hz_pause_10_5": "Pause 10.5h",
+          "hz_pause_11": "Pause 11.0h",
+          "hz_pause_11_5": "Pause 11.5h",
+          "hz_pause_12": "Pause 12.0h",
+          "hz_pause_1_5": "Pause 1.5h",
+          "hz_pause_2": "Pause 2.0h",
+          "hz_pause_2_5": "Pause 2.5h",
+          "hz_pause_3": "Pause 3.0h",
+          "hz_pause_3_5": "Pause 3.5h",
+          "hz_pause_4": "Pause 4.0h",
+          "hz_pause_4_5": "Pause 4.5h",
+          "hz_pause_5": "Pause 5.0h",
+          "hz_pause_5_5": "Pause 5.5h",
+          "hz_pause_6": "Pause 6.0h",
+          "hz_pause_6_5": "Pause 6.5h",
+          "hz_pause_7": "Pause 7.0h",
+          "hz_pause_7_5": "Pause 7.5h",
+          "hz_pause_8": "Pause 8.0h",
+          "hz_pause_8_5": "Pause 8.5h",
+          "hz_pause_9": "Pause 9.0h",
+          "hz_pause_9_5": "Pause 9.5h"
+        }
+      },
+      "party_pause2": {
+        "name": "{prefix}Pause / Party2",
+        "state": {
+          "hz_party_0_5": "Party 0.5h",
+          "hz_party_1": "Party 1.0h",
+          "hz_party_10": "Party 10.0h",
+          "hz_party_10_5": "Party 10.5h",
+          "hz_party_11": "Party 11.0h",
+          "hz_party_11_5": "Party 11.5h",
+          "hz_party_12": "Party 12.0h",
+          "hz_party_1_5": "Party 1.5h",
+          "hz_party_2": "Party 2.0h",
+          "hz_party_2_5": "Party 2.5h",
+          "hz_party_3": "Party 3.0h",
+          "hz_party_3_5": "Party 3.5h",
+          "hz_party_4": "Party 4.0h",
+          "hz_party_4_5": "Party 4.5h",
+          "hz_party_5": "Party 5.0h",
+          "hz_party_5_5": "Party 5.5h",
+          "hz_party_6": "Party 6.0h",
+          "hz_party_6_5": "Party 6.5h",
+          "hz_party_7": "Party 7.0h",
+          "hz_party_7_5": "Party 7.5h",
+          "hz_party_8": "Party 8.0h",
+          "hz_party_8_5": "Party 8.5h",
+          "hz_party_9": "Party 9.0h",
+          "hz_party_9_5": "Party 9.5h",
+          "hz_party_pause_auto": "Automatic",
+          "hz_pause_0_5": "Pause 0.5h",
+          "hz_pause_1": "Pause 1.0h",
+          "hz_pause_10": "Pause 10.0h",
+          "hz_pause_10_5": "Pause 10.5h",
+          "hz_pause_11": "Pause 11.0h",
+          "hz_pause_11_5": "Pause 11.5h",
+          "hz_pause_12": "Pause 12.0h",
+          "hz_pause_1_5": "Pause 1.5h",
+          "hz_pause_2": "Pause 2.0h",
+          "hz_pause_2_5": "Pause 2.5h",
+          "hz_pause_3": "Pause 3.0h",
+          "hz_pause_3_5": "Pause 3.5h",
+          "hz_pause_4": "Pause 4.0h",
+          "hz_pause_4_5": "Pause 4.5h",
+          "hz_pause_5": "Pause 5.0h",
+          "hz_pause_5_5": "Pause 5.5h",
+          "hz_pause_6": "Pause 6.0h",
+          "hz_pause_6_5": "Pause 6.5h",
+          "hz_pause_7": "Pause 7.0h",
+          "hz_pause_7_5": "Pause 7.5h",
+          "hz_pause_8": "Pause 8.0h",
+          "hz_pause_8_5": "Pause 8.5h",
+          "hz_pause_9": "Pause 9.0h",
+          "hz_pause_9_5": "Pause 9.5h"
+        }
+      },
+      "party_pause3": {
+        "name": "{prefix}Pause / Party3",
+        "state": {
+          "hz_party_0_5": "Party 0.5h",
+          "hz_party_1": "Party 1.0h",
+          "hz_party_10": "Party 10.0h",
+          "hz_party_10_5": "Party 10.5h",
+          "hz_party_11": "Party 11.0h",
+          "hz_party_11_5": "Party 11.5h",
+          "hz_party_12": "Party 12.0h",
+          "hz_party_1_5": "Party 1.5h",
+          "hz_party_2": "Party 2.0h",
+          "hz_party_2_5": "Party 2.5h",
+          "hz_party_3": "Party 3.0h",
+          "hz_party_3_5": "Party 3.5h",
+          "hz_party_4": "Party 4.0h",
+          "hz_party_4_5": "Party 4.5h",
+          "hz_party_5": "Party 5.0h",
+          "hz_party_5_5": "Party 5.5h",
+          "hz_party_6": "Party 6.0h",
+          "hz_party_6_5": "Party 6.5h",
+          "hz_party_7": "Party 7.0h",
+          "hz_party_7_5": "Party 7.5h",
+          "hz_party_8": "Party 8.0h",
+          "hz_party_8_5": "Party 8.5h",
+          "hz_party_9": "Party 9.0h",
+          "hz_party_9_5": "Party 9.5h",
+          "hz_party_pause_auto": "Automatic",
+          "hz_pause_0_5": "Pause 0.5h",
+          "hz_pause_1": "Pause 1.0h",
+          "hz_pause_10": "Pause 10.0h",
+          "hz_pause_10_5": "Pause 10.5h",
+          "hz_pause_11": "Pause 11.0h",
+          "hz_pause_11_5": "Pause 11.5h",
+          "hz_pause_12": "Pause 12.0h",
+          "hz_pause_1_5": "Pause 1.5h",
+          "hz_pause_2": "Pause 2.0h",
+          "hz_pause_2_5": "Pause 2.5h",
+          "hz_pause_3": "Pause 3.0h",
+          "hz_pause_3_5": "Pause 3.5h",
+          "hz_pause_4": "Pause 4.0h",
+          "hz_pause_4_5": "Pause 4.5h",
+          "hz_pause_5": "Pause 5.0h",
+          "hz_pause_5_5": "Pause 5.5h",
+          "hz_pause_6": "Pause 6.0h",
+          "hz_pause_6_5": "Pause 6.5h",
+          "hz_pause_7": "Pause 7.0h",
+          "hz_pause_7_5": "Pause 7.5h",
+          "hz_pause_8": "Pause 8.0h",
+          "hz_pause_8_5": "Pause 8.5h",
+          "hz_pause_9": "Pause 9.0h",
+          "hz_pause_9_5": "Pause 9.5h"
+        }
+      },
+      "party_pause4": {
+        "name": "{prefix}Pause / Party4",
+        "state": {
+          "hz_party_0_5": "Party 0.5h",
+          "hz_party_1": "Party 1.0h",
+          "hz_party_10": "Party 10.0h",
+          "hz_party_10_5": "Party 10.5h",
+          "hz_party_11": "Party 11.0h",
+          "hz_party_11_5": "Party 11.5h",
+          "hz_party_12": "Party 12.0h",
+          "hz_party_1_5": "Party 1.5h",
+          "hz_party_2": "Party 2.0h",
+          "hz_party_2_5": "Party 2.5h",
+          "hz_party_3": "Party 3.0h",
+          "hz_party_3_5": "Party 3.5h",
+          "hz_party_4": "Party 4.0h",
+          "hz_party_4_5": "Party 4.5h",
+          "hz_party_5": "Party 5.0h",
+          "hz_party_5_5": "Party 5.5h",
+          "hz_party_6": "Party 6.0h",
+          "hz_party_6_5": "Party 6.5h",
+          "hz_party_7": "Party 7.0h",
+          "hz_party_7_5": "Party 7.5h",
+          "hz_party_8": "Party 8.0h",
+          "hz_party_8_5": "Party 8.5h",
+          "hz_party_9": "Party 9.0h",
+          "hz_party_9_5": "Party 9.5h",
+          "hz_party_pause_auto": "Automatic",
+          "hz_pause_0_5": "Pause 0.5h",
+          "hz_pause_1": "Pause 1.0h",
+          "hz_pause_10": "Pause 10.0h",
+          "hz_pause_10_5": "Pause 10.5h",
+          "hz_pause_11": "Pause 11.0h",
+          "hz_pause_11_5": "Pause 11.5h",
+          "hz_pause_12": "Pause 12.0h",
+          "hz_pause_1_5": "Pause 1.5h",
+          "hz_pause_2": "Pause 2.0h",
+          "hz_pause_2_5": "Pause 2.5h",
+          "hz_pause_3": "Pause 3.0h",
+          "hz_pause_3_5": "Pause 3.5h",
+          "hz_pause_4": "Pause 4.0h",
+          "hz_pause_4_5": "Pause 4.5h",
+          "hz_pause_5": "Pause 5.0h",
+          "hz_pause_5_5": "Pause 5.5h",
+          "hz_pause_6": "Pause 6.0h",
+          "hz_pause_6_5": "Pause 6.5h",
+          "hz_pause_7": "Pause 7.0h",
+          "hz_pause_7_5": "Pause 7.5h",
+          "hz_pause_8": "Pause 8.0h",
+          "hz_pause_8_5": "Pause 8.5h",
+          "hz_pause_9": "Pause 9.0h",
+          "hz_pause_9_5": "Pause 9.5h"
+        }
+      },
+      "party_pause5": {
+        "name": "{prefix}Pause / Party5",
+        "state": {
+          "hz_party_0_5": "Party 0.5h",
+          "hz_party_1": "Party 1.0h",
+          "hz_party_10": "Party 10.0h",
+          "hz_party_10_5": "Party 10.5h",
+          "hz_party_11": "Party 11.0h",
+          "hz_party_11_5": "Party 11.5h",
+          "hz_party_12": "Party 12.0h",
+          "hz_party_1_5": "Party 1.5h",
+          "hz_party_2": "Party 2.0h",
+          "hz_party_2_5": "Party 2.5h",
+          "hz_party_3": "Party 3.0h",
+          "hz_party_3_5": "Party 3.5h",
+          "hz_party_4": "Party 4.0h",
+          "hz_party_4_5": "Party 4.5h",
+          "hz_party_5": "Party 5.0h",
+          "hz_party_5_5": "Party 5.5h",
+          "hz_party_6": "Party 6.0h",
+          "hz_party_6_5": "Party 6.5h",
+          "hz_party_7": "Party 7.0h",
+          "hz_party_7_5": "Party 7.5h",
+          "hz_party_8": "Party 8.0h",
+          "hz_party_8_5": "Party 8.5h",
+          "hz_party_9": "Party 9.0h",
+          "hz_party_9_5": "Party 9.5h",
+          "hz_party_pause_auto": "Automatic",
+          "hz_pause_0_5": "Pause 0.5h",
+          "hz_pause_1": "Pause 1.0h",
+          "hz_pause_10": "Pause 10.0h",
+          "hz_pause_10_5": "Pause 10.5h",
+          "hz_pause_11": "Pause 11.0h",
+          "hz_pause_11_5": "Pause 11.5h",
+          "hz_pause_12": "Pause 12.0h",
+          "hz_pause_1_5": "Pause 1.5h",
+          "hz_pause_2": "Pause 2.0h",
+          "hz_pause_2_5": "Pause 2.5h",
+          "hz_pause_3": "Pause 3.0h",
+          "hz_pause_3_5": "Pause 3.5h",
+          "hz_pause_4": "Pause 4.0h",
+          "hz_pause_4_5": "Pause 4.5h",
+          "hz_pause_5": "Pause 5.0h",
+          "hz_pause_5_5": "Pause 5.5h",
+          "hz_pause_6": "Pause 6.0h",
+          "hz_pause_6_5": "Pause 6.5h",
+          "hz_pause_7": "Pause 7.0h",
+          "hz_pause_7_5": "Pause 7.5h",
+          "hz_pause_8": "Pause 8.0h",
+          "hz_pause_8_5": "Pause 8.5h",
+          "hz_pause_9": "Pause 9.0h",
+          "hz_pause_9_5": "Pause 9.5h"
+        }
+      },
+      "sys_operationmode": {
+        "name": "{prefix}System operation mode",
+        "state": {
+          "sys_operationmode_2ndheatsource": "2nd heat source",
+          "sys_operationmode_automatic": "Automatic",
+          "sys_operationmode_heating": "Heating",
+          "sys_operationmode_cooling": "Cooling",
+          "sys_operationmode_summer": "Summer",
+          "sys_operationmode_standby": "Standby"
+        }
+      },
+      "ww_push": {
+        "name": "{prefix}Hot water Push",
+        "state": {
+          "ww_push_10": "10 min",
+          "ww_push_100": "100 min",
+          "ww_push_105": "105 min",
+          "ww_push_110": "110 min",
+          "ww_push_115": "115 min",
+          "ww_push_120": "120 min",
+          "ww_push_125": "125 min",
+          "ww_push_130": "130 min",
+          "ww_push_135": "135 min",
+          "ww_push_140": "140 min",
+          "ww_push_145": "145 min",
+          "ww_push_15": "15 min",
+          "ww_push_150": "150 min",
+          "ww_push_155": "155 min",
+          "ww_push_160": "160 min",
+          "ww_push_165": "165 min",
+          "ww_push_170": "170 min",
+          "ww_push_175": "175 min",
+          "ww_push_180": "180 min",
+          "ww_push_185": "185 min",
+          "ww_push_190": "190 min",
+          "ww_push_195": "195 min",
+          "ww_push_20": "20 min",
+          "ww_push_200": "200 min",
+          "ww_push_205": "205 min",
+          "ww_push_210": "210 min",
+          "ww_push_215": "215 min",
+          "ww_push_220": "220 min",
+          "ww_push_225": "225 min",
+          "ww_push_230": "230 min",
+          "ww_push_235": "235 min",
+          "ww_push_25": "25 min",
+          "ww_push_30": "30 min",
+          "ww_push_35": "35 min",
+          "ww_push_40": "40 min",
+          "ww_push_45": "45 min",
+          "ww_push_5": "5 min",
+          "ww_push_50": "50 min",
+          "ww_push_55": "55 min",
+          "ww_push_60": "60 min",
+          "ww_push_65": "65 min",
+          "ww_push_70": "70 min",
+          "ww_push_75": "75 min",
+          "ww_push_80": "80 min",
+          "ww_push_85": "85 min",
+          "ww_push_90": "90 min",
+          "ww_push_95": "95 min",
+          "ww_push_aus": "off"
+        }
+      }
     },
-    "title": "Weishaupt Heat Pump"
+    "sensor": {
+      "abtau_energie_gester": {
+        "name": "{prefix}Defrost energy yesterday"
+      },
+      "abtau_energie_heute": {
+        "name": "{prefix}Defrost energy today"
+      },
+      "abtau_energie_jahr": {
+        "name": "{prefix}Defrost energy year"
+      },
+      "abtau_energie_monat": {
+        "name": "{prefix}Defrost energy month"
+      },
+      "adr31106": {
+        "name": "{prefix}Adr. 31106"
+      },
+      "adr311062": {
+        "name": "{prefix}Adr. 311062"
+      },
+      "adr311063": {
+        "name": "{prefix}Adr. 311063"
+      },
+      "adr311064": {
+        "name": "{prefix}Adr. 311064"
+      },
+      "adr311065": {
+        "name": "{prefix}Adr. 311065"
+      },
+      "adr36801": {
+        "name": "{prefix}Adr. 36801"
+      },
+      "adr44102": {
+        "name": "{prefix}Configuration EP1",
+        "state": {
+          "w2_konf_0": "enabled",
+          "w2_konf_1": "OFF"
+        }
+      },
+      "adr44103": {
+        "name": "{prefix}Configuration EP2",
+        "state": {
+          "w2_konf_0": "enabled",
+          "w2_konf_1": "OFF"
+        }
+      },
+      "anf_typ": {
+        "name": "{prefix}Request type",
+        "state": {
+          "hz_anforderung_aus": "off",
+          "hz_anforderung_konstant": "constant",
+          "hz_anforderung_witterungsgefuehrt": "weather-guided"
+        }
+      },
+      "anf_typ2": {
+        "name": "{prefix}Request type2",
+        "state": {
+          "hz_anforderung_aus": "off",
+          "hz_anforderung_konstant": "constrant",
+          "hz_anforderung_witterungsgefuehrt": "weather-guided"
+        }
+      },
+      "anf_typ3": {
+        "name": "{prefix}Request type3",
+        "state": {
+          "hz_anforderung_aus": "off",
+          "hz_anforderung_konstant": "constrant",
+          "hz_anforderung_witterungsgefuehrt": "weather-guided"
+        }
+      },
+      "anf_typ4": {
+        "name": "{prefix}Request type4",
+        "state": {
+          "hz_anforderung_aus": "off",
+          "hz_anforderung_konstant": "constrant",
+          "hz_anforderung_witterungsgefuehrt": "weather-guided"
+        }
+      },
+      "anf_typ5": {
+        "name": "{prefix}Request type5",
+        "state": {
+          "hz_anforderung_aus": "off",
+          "hz_anforderung_konstant": "constrant",
+          "hz_anforderung_witterungsgefuehrt": "weather-guided"
+        }
+      },
+      "anforderung_vl_regenerativ": {
+        "name": "{prefix}Request(feed regenerative)"
+      },
+      "ausg_h12": {
+        "name": "{prefix}Output H1.2"
+      },
+      "ausg_h13": {
+        "name": "{prefix}Output H1.3"
+      },
+      "ausg_h14": {
+        "name": "{prefix}Output H1.4"
+      },
+      "ausg_h15": {
+        "name": "{prefix}Output H1.5"
+      },
+      "aussentemp": {
+        "name": "{prefix}Outside temperature"
+      },
+      "betriebsanzeige": {
+        "name": "{prefix}Operation indicator",
+        "state": {
+          "system_operationmode_undefined": "undefined",
+          "system_operationmode_relaistest": "Relais test",
+          "system_operationmode_sgtariff": "SG tariff",
+          "system_operationmode_sgmax": "SG maximum",
+          "system_operationmode_tariffload": "Tariff load",
+          "system_operationmode_elevatedoperation": "Elevated operation",
+          "system_operationmode_standbytime": "Standby time",
+          "system_operationmode_standby": "Standby",
+          "system_operationmode_rinse": "Rinse",
+          "system_operationmode_frosprotection": "Frost protection",
+          "system_operationmode_heating": "Heating mode",
+          "system_operationmode_emergencystop": "Emergency stop",
+          "system_operationmode_hotwater": "Hot water mode",
+          "system_operationmode_legionellaprotection": "Legionella protection",
+          "system_operationmode_switchheatingcooling": "Switchover HZ KU",
+          "system_operationmode_cooling": "Cooling mode",
+          "system_operationmode_passivecooling": "Passive cooling",
+          "system_operationmode_summer": "Summer mode",
+          "system_operationmode_swimmingpool": "Swimming pool mode",
+          "system_operationmode_vacation": "Vacation",
+          "system_operationmode_screedprogram": "Screed program",
+          "system_operationmode_locked": "Locked",
+          "system_operationmode_diagnosis": "Diagnosis",
+          "system_operationmode_lockedat": "Lock AT",
+          "system_operationmode_lockedsummer": "Lock summer",
+          "system_operationmode_lockedwinter": "Winter lock",
+          "system_operationmode_applicationlimit": "Application limit",
+          "system_operationmode_lockedcv": "HK block",
+          "system_operationmode_lowering": "Lowering mode",
+          "system_operationmode_regenerativeflow": "Regenerative flow",
+          "system_operationmode_manual": "Manual mode",
+          "system_operationmode_oilrecirculation": "Oil recirculation",
+          "system_operationmode_manualheating": "Manual heating",
+          "system_operationmode_manualcooling": "Manual cooling",
+          "system_operationmode_manualdefrost": "Manual defrost",
+          "system_operationmode_defrost": "Defrost",
+          "system_operationmode_manual2ndheatsource": "2nd heat source"
+        }
+      },
+      "betriebss_e1": {
+        "name": "{prefix}Operation hours E1"
+      },
+      "betriebss_e2": {
+        "name": "{prefix}Operation hours E2"
+      },
+      "eing_de1": {
+        "name": "{prefix}Input DE1",
+        "state": {
+          "w2_status_aus": "off",
+          "w2_status_ein": "on"
+        }
+      },
+      "eing_de2": {
+        "name": "{prefix}Input DE2",
+        "state": {
+          "w2_status_aus": "off",
+          "w2_status_ein": "on"
+        }
+      },
+      "el_energie_yesterday": {
+        "name": "{prefix}Electr. energy yesterday"
+      },
+      "el_energie_heute": {
+        "name": "{prefix}Electr. energy today"
+      },
+      "el_energie_jahr": {
+        "name": "{prefix}Electr. energy year"
+      },
+      "el_energie_monat": {
+        "name": "{prefix}Electr. energy month"
+      },
+      "fehler": {
+        "name": "{prefix}Fehler",
+        "state": {
+          "sys_fehler_1": "Refrigerant sensor expansion valve inlet (T1)",
+          "sys_fehler_10": "High pressure sensor (P2)",
+          "sys_fehler_101": "Heat pump is being operated outside the operating limits",
+          "sys_fehler_102": "Maximum defrost time exceeded",
+          "sys_fehler_103": "Communication refrigeration circuit faulty",
+          "sys_fehler_104": "discharge gas temperature too high",
+          "sys_fehler_105": "Current consumption from inverter too high",
+          "sys_fehler_106": "Current consumption too high",
+          "sys_fehler_107": "DC voltage on inverter too high",
+          "sys_fehler_108": "DC voltage on inverter too low",
+          "sys_fehler_109": "Heat pump is operated outside the permissible voltage range",
+          "sys_fehler_11": "Medium pressure sensor (P3)",
+          "sys_fehler_110": "Heat pump is being operated outside the permissible voltage range",
+          "sys_fehler_111": "High pressure switch has triggered",
+          "sys_fehler_112": "Inverter has overheated",
+          "sys_fehler_113": "Inverter has overheated",
+          "sys_fehler_114": "Position of compressor motor cannot be determined",
+          "sys_fehler_117": "DC voltage on inverter too low",
+          "sys_fehler_118": "Current between inverter and compressor is too high",
+          "sys_fehler_119": "Current consumption from compressor too high Timeout",
+          "sys_fehler_12": "Cooling expansion valve defective",
+          "sys_fehler_120": "Inverter temperature too high",
+          "sys_fehler_121": "Voltage on inverter too low",
+          "sys_fehler_122": "Modbus configuration error",
+          "sys_fehler_123": "No Modbus connection",
+          "sys_fehler_124": "discharge gas temperature too high",
+          "sys_fehler_127": "Inverter temperature too high",
+          "sys_fehler_128": "Inverter is overheated",
+          "sys_fehler_129": "Modbus communication faulty",
+          "sys_fehler_13": "No communication to the inverter",
+          "sys_fehler_130": "Modbus communication faulty",
+          "sys_fehler_133": "Electronics error",
+          "sys_fehler_135": "High pressure switch defective",
+          "sys_fehler_136": "Compressor does not match configuration",
+          "sys_fehler_137": "High pressure switch does not match the configuration",
+          "sys_fehler_14": "No communication with the outdoor unit",
+          "sys_fehler_140": "discharge gas temperature too low",
+          "sys_fehler_143": "Inverter temperature too low",
+          "sys_fehler_144": "Choke coil temperature too low",
+          "sys_fehler_15": "High pressure switch has triggered",
+          "sys_fehler_150": "Compressor current sensor phase U error",
+          "sys_fehler_151": "Compressor current sensor phase V error",
+          "sys_fehler_152": "Compressor current sensor phase W error voltage supply from input terminal",
+          "sys_fehler_153": "Current sensor error",
+          "sys_fehler_154": "Inverter temperature sensor error",
+          "sys_fehler_155": "Temperature sensor error",
+          "sys_fehler_156": "Compressed gas sensor (DT)",
+          "sys_fehler_157": "No communication to the cooling unit control board",
+          "sys_fehler_158": "EEPROM memory error",
+          "sys_fehler_159": "Current consumption too high",
+          "sys_fehler_16": "Inverter disabled because 10 errors have occurred in the last 10 hours",
+          "sys_fehler_160": "Heat pump is being operated outside the permissible voltage range",
+          "sys_fehler_161": "Heat pump is being operated outside the permissible voltage range",
+          "sys_fehler_162": "DC voltage on inverter too high",
+          "sys_fehler_163": "DC voltage on inverter too low",
+          "sys_fehler_164": "High pressure switch has triggered",
+          "sys_fehler_165": "Phase between input and compressor interrupted",
+          "sys_fehler_166": "Inverter overheated",
+          "sys_fehler_167": "Inverter overheated",
+          "sys_fehler_168": "Compressor configuration error",
+          "sys_fehler_169": "Compressor current consumption too high",
+          "sys_fehler_17": "EEPROM memory error",
+          "sys_fehler_170": "Compressor phase U overvoltage",
+          "sys_fehler_171": "Compressor phase V overvoltage",
+          "sys_fehler_172": "Compressor phase W overvoltage",
+          "sys_fehler_173": "Compressor phase failure",
+          "sys_fehler_174": "Compressor blocked",
+          "sys_fehler_175": "Compressor does not start",
+          "sys_fehler_176": "Irregular voltage supply from inverter",
+          "sys_fehler_177": "Compressor overloaded",
+          "sys_fehler_178": "Temperature at discharge gas sensor (DT) too high",
+          "sys_fehler_179": "Temperature at inverter",
+          "sys_fehler_18": "No Modbus communication between EC controller and refrigeration unit control board",
+          "sys_fehler_180": "Compressor blocked",
+          "sys_fehler_181": "Compressor blocked",
+          "sys_fehler_182": "Current consumption too high",
+          "sys_fehler_183": "Current consumption too high",
+          "sys_fehler_184": "Voltage too high",
+          "sys_fehler_19": "Heat pump switched off by inverter alarm",
+          "sys_fehler_2": "Air intake sensor (T2)",
+          "sys_fehler_20": "Compressor does not match the configuration",
+          "sys_fehler_21": "Low pressure fault",
+          "sys_fehler_22": "Insufficient superheat",
+          "sys_fehler_23": "excessive superheat",
+          "sys_fehler_24": "EVI too high overheating",
+          "sys_fehler_25": "Refrigerant quantity too low",
+          "sys_fehler_26": "High pressure fault",
+          "sys_fehler_27": "Condensation temperature too low",
+          "sys_fehler_28": "Condensation temperature too high",
+          "sys_fehler_29": "Evaporation temperature too low",
+          "sys_fehler_3": "Heat exchanger sensor AG outlet (T3)",
+          "sys_fehler_30": "Evaporation temperature too high",
+          "sys_fehler_32": "Heat pump not compatible",
+          "sys_fehler_33": "Controller EC has no connection to expansion module EM-HK",
+          "sys_fehler_4": "Compressor suction gas sensor (T4)",
+          "sys_fehler_40": "Volume flow too low",
+          "sys_fehler_41": "Spreizung LWT/Rücklauf negative / four-way valve does not switch back after defrosting; the system locks after 3 warnings)",
+          "sys_fehler_43": "Fan blocked",
+          "sys_fehler_44": "Fan speed too low",
+          "sys_fehler_47": "Communication controller EC to control board refrigeration unit faulty",
+          "sys_fehler_5": "EVI suction gas sensor (T5)",
+          "sys_fehler_50": "Outdoor sensor (B1) interrupted",
+          "sys_fehler_51": "Outdoor sensor (B1) short-circuited",
+          "sys_fehler_52": "Point sensor (B2) interrupted",
+          "sys_fehler_53": "Point sensor (B2) short-circuited",
+          "sys_fehler_54": "Hot water sensor (B3) interrupted",
+          "sys_fehler_55": "Hot water sensor (B3) short-circuited",
+          "sys_fehler_56": "Condenser flow sensor (B4) interrupted",
+          "sys_fehler_57": "Condenser flow sensor (B4) short-circuited",
+          "sys_fehler_58": "Flow sensor (B7) interrupted",
+          "sys_fehler_59": "Flow sensor (B7) short-circuited",
+          "sys_fehler_6": "Refrigerant sensor IG outlet (T6)",
+          "sys_fehler_60": "Return flow sensor (B9) interrupted",
+          "sys_fehler_61": "Return flow sensor (B9) short-circuited",
+          "sys_fehler_64": "Buffer sensor (B11) interrupted",
+          "sys_fehler_65": "Buffer sensor (B11) short-circuited",
+          "sys_fehler_65535": "no error",
+          "sys_fehler_66": "Regenerative mixer sensor (B2.1) interrupted",
+          "sys_fehler_67": "Regenerative mixer sensor (B2.1) short-circuited",
+          "sys_fehler_7": "Oil sump sensor (T7)",
+          "sys_fehler_70": "Second heating circuit flow sensor (B6.2) interrupted",
+          "sys_fehler_71": "Second heating circuit flow sensor (B6.2) short-circuited",
+          "sys_fehler_72": "Sensor (T1.2) interrupted",
+          "sys_fehler_73": "Sensor (T1.2) short-circuited",
+          "sys_fehler_74": "Sensor (T2.2) interrupted",
+          "sys_fehler_75": "Sensor (T2.2) short-circuited",
+          "sys_fehler_8": "Expansion valve EVI",
+          "sys_fehler_9": "Low pressure sensor (P1)",
+          "sys_fehler_90": "Analog input AE1 interrupted",
+          "sys_fehler_91": "Analog input AE1 short-circuited",
+          "sys_fehler_92": "Analog input AE2 interrupted",
+          "sys_fehler_93": "Analog input AE2 short-circuited",
+          "sys_fehler_94": "Analog input AE3 interrupted",
+          "sys_fehler_95": "Analog input AE3 short-circuited"
+        }
+      },
+      "fehlerfrei": {
+        "name": "{prefix}No error",
+        "state": {
+          "fehler_aktiv": "Error active",
+          "stoerungsfreier_betrieb": "Fault-free operation"
+        }
+      },
+      "ges_energie_2_yesterday": {
+        "name": "{prefix}Total energy II yesterday"
+      },
+      "ges_energie_2_heute": {
+        "name": "{prefix}Total energy II today"
+      },
+      "ges_energie_2_jahr": {
+        "name": "{prefix}Total energy II year"
+      },
+      "ges_energie_2_monat": {
+        "name": "{prefix}Total energy II month"
+      },
+      "ges_energie_yesterday": {
+        "name": "{prefix}Total energy yesterday"
+      },
+      "ges_energie_heute": {
+        "name": "{prefix}Total energy today"
+      },
+      "ges_energie_jahr": {
+        "name": "{prefix}Total energy year"
+      },
+      "ges_energie_monat": {
+        "name": "{prefix}Total energy month"
+      },
+      "heiz_energie_getern": {
+        "name": "{prefix}Heating energy yesterday"
+      },
+      "heiz_energie_heute": {
+        "name": "{prefix}Heating energy today"
+      },
+      "heiz_energie_jahr": {
+        "name": "{prefix}Heating energy year"
+      },
+      "heiz_energie_monat": {
+        "name": "{prefix}Heating energy month"
+      },
+      "heiz_konstanttemp": {
+        "name": "{prefix}Heating constant temperature"
+      },
+      "heiz_konstanttemp2": {
+        "name": "{prefix}Heating constant temperature 2"
+      },
+      "heiz_konstanttemp3": {
+        "name": "{prefix}Heating constant temperature 3"
+      },
+      "heiz_konstanttemp4": {
+        "name": "{prefix}Heating constant temperature 4"
+      },
+      "heiz_konstanttemp5": {
+        "name": "{prefix}Heating constant temperature 5"
+      },
+      "heiz_konstanttemp_absenk": {
+        "name": "{prefix}Heating constant temp. lowering"
+      },
+      "heiz_konstanttemp_absenk2": {
+        "name": "{prefix}Heating constant temp. lowering2"
+      },
+      "heiz_konstanttemp_absenk3": {
+        "name": "{prefix}Heating constant temp. lowering3"
+      },
+      "heiz_konstanttemp_absenk4": {
+        "name": "{prefix}Heating constant temp. lowering4"
+      },
+      "heiz_konstanttemp_absenk5": {
+        "name": "{prefix}Heating constant temp. lowering5"
+      },
+      "hz_konf": {
+        "name": "{prefix}Heating circuit configuration",
+        "state": {
+          "hp_konf_aus": "off",
+          "hp_konf_mischkreis": "Mixing circuit",
+          "hp_konf_pumpenkreis": "Pump circuit",
+          "hp_konf_sollwert_pumpe_m1": "Setpoint (pump M1)"
+        }
+      },
+      "hz_konf2": {
+        "name": "{prefix}Heating circuit configuration 2",
+        "state": {
+          "hp_konf_aus": "off",
+          "hp_konf_mischkreis": "Mixing circuit",
+          "hp_konf_pumpenkreis": "Pump circuit",
+          "hp_konf_sollwert_pumpe_m1": "Setpoint (pump M1)"
+        }
+      },
+      "hz_konf3": {
+        "name": "{prefix}Heating circuit configuration 3",
+        "state": {
+          "hp_konf_aus": "off",
+          "hp_konf_mischkreis": "Mixing circuit",
+          "hp_konf_pumpenkreis": "Pump circuit",
+          "hp_konf_sollwert_pumpe_m1": "Setpoint (pump M1)"
+        }
+      },
+      "hz_konf4": {
+        "name": "{prefix}Heating circuit configuration 4",
+        "state": {
+          "hp_konf_aus": "off",
+          "hp_konf_mischkreis": "Mixing circuit",
+          "hp_konf_pumpenkreis": "Pump circuit",
+          "hp_konf_sollwert_pumpe_m1": "Setpoint (pump M1)"
+        }
+      },
+      "hz_konf5": {
+        "name": "{prefix}Heating circuit configuration 5",
+        "state": {
+          "hp_konf_aus": "off",
+          "hp_konf_mischkreis": "Mixing circuit",
+          "hp_konf_pumpenkreis": "Pump circuit",
+          "hp_konf_sollwert_pumpe_m1": "Setpoint (pump M1)"
+        }
+      },
+      "hz_vl_temp": {
+        "name": "{prefix}Heat circuit feed temperature"
+      },
+      "hz_vl_temp2": {
+        "name": "{prefix}Heat circuit feed temperature 2"
+      },
+      "hz_vl_temp3": {
+        "name": "{prefix}Heat circuit feed temperature 3"
+      },
+      "hz_vl_temp4": {
+        "name": "{prefix}Heat circuit feed temperature 4"
+      },
+      "hz_vl_temp5": {
+        "name": "{prefix}Heat circuit feed temperature 5"
+      },
+      "hz_vl_solltemp": {
+        "name": "{prefix}Heat circuit feed setpoint temperature"
+      },
+      "hz_vl_solltemp2": {
+        "name": "{prefix}Heat circuit feed setpoint temperature2"
+      },
+      "hz_vl_solltemp3": {
+        "name": "{prefix}Heat circuit feed setpoint temperature3"
+      },
+      "hz_vl_solltemp4": {
+        "name": "{prefix}Heat circuit feed setpoint temperature4"
+      },
+      "hz_vl_solltemp5": {
+        "name": "{prefix}Heat circuit feed setpoint temperature5"
+      },
+      "konf_ausg_h12": {
+        "name": "{prefix}Conf. Output H1.2",
+        "state": {
+          "io_konf_0": "0",
+          "io_konf_1": "1",
+          "io_konf_2": "2",
+          "io_konf_3": "3",
+          "io_konf_4": "4",
+          "io_konf_5": "5",
+          "io_konf_6": "6",
+          "io_konf_65535": "65535",
+          "io_konf_7": "7"
+        }
+      },
+      "konf_ausg_h13": {
+        "name": "{prefix}Conf. Output  H1.3",
+        "state": {
+          "io_konf_0": "0",
+          "io_konf_1": "1",
+          "io_konf_2": "2",
+          "io_konf_3": "3",
+          "io_konf_4": "4",
+          "io_konf_5": "5",
+          "io_konf_6": "6",
+          "io_konf_65535": "65535",
+          "io_konf_7": "7"
+        }
+      },
+      "konf_ausg_h14": {
+        "name": "{prefix}Conf. Output  H1.4",
+        "state": {
+          "io_konf_0": "0",
+          "io_konf_1": "1",
+          "io_konf_2": "2",
+          "io_konf_3": "3",
+          "io_konf_4": "4",
+          "io_konf_5": "5",
+          "io_konf_6": "6",
+          "io_konf_65535": "65535",
+          "io_konf_7": "7"
+        }
+      },
+      "konf_ausg_h15": {
+        "name": "{prefix}Conf. Output  H1.5",
+        "state": {
+          "io_konf_0": "0",
+          "io_konf_1": "1",
+          "io_konf_2": "2",
+          "io_konf_3": "3",
+          "io_konf_4": "4",
+          "io_konf_5": "5",
+          "io_konf_6": "6",
+          "io_konf_65535": "65535",
+          "io_konf_7": "7"
+        }
+      },
+      "konf_eing_de1": {
+        "name": "{prefix}Conf. Input DE1",
+        "state": {
+          "io_konf_in_0": "SG Ready",
+          "io_konf_in_1": "EVU block",
+          "io_konf_in_10": "Producer block HZ and WW",
+          "io_konf_in_11": "Hot water standby",
+          "io_konf_in_12": "Hot water lowering",
+          "io_konf_in_13": "Hot water normal",
+          "io_konf_in_14": "Hot water PUSH",
+          "io_konf_in_15": "Dew point monitor",
+          "io_konf_in_16": "Heating circuit ... Standby",
+          "io_konf_in_17": "Heating circuit ... lowering",
+          "io_konf_in_18": "Heating circuit ... normal",
+          "io_konf_in_19": "Heating circuit ... comfort",
+          "io_konf_in_2": "Increased operation",
+          "io_konf_in_20": "2nd heat source",
+          "io_konf_in_21": "Lock compressor",
+          "io_konf_in_3": "HK block",
+          "io_konf_in_4": "Hz/cooling changeover",
+          "io_konf_in_5": "Sleep mode",
+          "io_konf_in_6": "Emergency stop",
+          "io_konf_in_65535": "OFF",
+          "io_konf_in_7": "System standby",
+          "io_konf_in_8": "Producer lock HZ",
+          "io_konf_in_9": "Producer block WW"
+        }
+      },
+      "konf_eing_de2": {
+        "name": "{prefix}Conf. Input DE2",
+        "state": {
+          "io_konf_in_0": "SG Ready",
+          "io_konf_in_1": "EVU block",
+          "io_konf_in_10": "Producer block HZ and WW",
+          "io_konf_in_11": "Hot water standby",
+          "io_konf_in_12": "Hot water lowering",
+          "io_konf_in_13": "Hot water normal",
+          "io_konf_in_14": "Hot water PUSH",
+          "io_konf_in_15": "Dew point monitor",
+          "io_konf_in_16": "Heating circuit ... Standby",
+          "io_konf_in_17": "Heating circuit ... lowering",
+          "io_konf_in_18": "Heating circuit ... normal",
+          "io_konf_in_19": "Heating circuit ... comfort",
+          "io_konf_in_2": "Increased operation",
+          "io_konf_in_20": "2nd heat source",
+          "io_konf_in_21": "Lock compressor",
+          "io_konf_in_3": "HK block",
+          "io_konf_in_4": "Hz/cooling changeover",
+          "io_konf_in_5": "Sleep mode",
+          "io_konf_in_6": "Emergency stop",
+          "io_konf_in_65535": "OFF",
+          "io_konf_in_7": "System standby",
+          "io_konf_in_8": "Producer lock HZ",
+          "io_konf_in_9": "Producer block WW"
+        }
+      },
+      "konf_eing_sgr1": {
+        "name": "{prefix}Conf. Input SGR1",
+        "state": {
+          "io_konf_in_0": "SG Ready",
+          "io_konf_in_1": "EVU block",
+          "io_konf_in_10": "Producer block HZ and WW",
+          "io_konf_in_11": "Hot water standby",
+          "io_konf_in_12": "Hot water lowering",
+          "io_konf_in_13": "Hot water normal",
+          "io_konf_in_14": "Hot water PUSH",
+          "io_konf_in_15": "Dew point monitor",
+          "io_konf_in_16": "Heating circuit ... Standby",
+          "io_konf_in_17": "Heating circuit ... lowering",
+          "io_konf_in_18": "Heating circuit ... normal",
+          "io_konf_in_19": "Heating circuit ... comfort",
+          "io_konf_in_2": "Increased operation",
+          "io_konf_in_20": "2nd heat source",
+          "io_konf_in_21": "Lock compressor",
+          "io_konf_in_3": "HK block",
+          "io_konf_in_4": "Hz/cooling changeover",
+          "io_konf_in_5": "Sleep mode",
+          "io_konf_in_6": "Emergency stop",
+          "io_konf_in_65535": "OFF",
+          "io_konf_in_7": "System standby",
+          "io_konf_in_8": "Producer lock HZ",
+          "io_konf_in_9": "Producer block WW"
+        }
+      },
+      "konf_eing_sgr2": {
+        "name": "{prefix}Conf. Input SGR2",
+        "state": {
+          "io_konf_in_0": "SG Ready",
+          "io_konf_in_1": "EVU block",
+          "io_konf_in_10": "Producer block HZ and WW",
+          "io_konf_in_11": "Hot water standby",
+          "io_konf_in_12": "Hot water lowering",
+          "io_konf_in_13": "Hot water normal",
+          "io_konf_in_14": "Hot water PUSH",
+          "io_konf_in_15": "Dew point monitor",
+          "io_konf_in_16": "Heating circuit ... Standby",
+          "io_konf_in_17": "Heating circuit ... lowering",
+          "io_konf_in_18": "Heating circuit ... normal",
+          "io_konf_in_19": "Heating circuit ... comfort",
+          "io_konf_in_2": "Increased operation",
+          "io_konf_in_20": "2nd heat source",
+          "io_konf_in_21": "Lock compressor",
+          "io_konf_in_3": "HK block",
+          "io_konf_in_4": "Hz/cooling changeover",
+          "io_konf_in_5": "Sleep mode",
+          "io_konf_in_6": "Emergency stop",
+          "io_konf_in_65535": "OFF",
+          "io_konf_in_7": "System standby",
+          "io_konf_in_8": "Producer lock HZ",
+          "io_konf_in_9": "Producer block WW"
+        }
+      },
+      "kuehl_energie_yesterday": {
+        "name": "{prefix}Cooling energy yesterday"
+      },
+      "kuehl_energie_heute": {
+        "name": "{prefix}Cooling energy heute"
+      },
+      "kuehl_energie_jahr": {
+        "name": "{prefix}Cooling energy year"
+      },
+      "kuehl_energie_monat": {
+        "name": "{prefix}Cooling energy month"
+      },
+      "kuehl_konstanttemp": {
+        "name": "{prefix}Cooling constant temperature"
+      },
+      "kuehl_konstanttemp2": {
+        "name": "{prefix}Cooling constant temperature 2"
+      },
+      "kuehl_konstanttemp3": {
+        "name": "{prefix}Cooling constant temperature 3"
+      },
+      "kuehl_konstanttemp4": {
+        "name": "{prefix}Cooling constant temperature 4"
+      },
+      "kuehl_konstanttemp5": {
+        "name": "{prefix}Cooling constant temperature 5"
+      },
+      "leistungsanforderung": {
+        "name": "{prefix}Power request"
+      },
+      "luftansautgemp": {
+        "name": "{prefix}Air intake temperature"
+      },
+      "puffer_temp": {
+        "name": "{prefix}Buffer temperature"
+      },
+      "pumpe_einschaltart": {
+        "name": "{prefix}Pump operation mode"
+      },
+      "raum_feuchte": {
+        "name": "{prefix}Room humidity"
+      },
+      "raum_feuchte2": {
+        "name": "{prefix}Room humidity 2"
+      },
+      "raum_feuchte3": {
+        "name": "{prefix}Room humidity 3"
+      },
+      "raum_feuchte4": {
+        "name": "{prefix}Room humidity 4"
+      },
+      "raum_feuchte5": {
+        "name": "{prefix}Room humidity 5"
+      },
+      "raum_soll_temp": {
+        "name": "{prefix}Room setpoint temperature"
+      },
+      "raum_soll_temp2": {
+        "name": "{prefix}Room setpoint temperature 2"
+      },
+      "raum_soll_temp3": {
+        "name": "{prefix}Room setpoint temperature 3"
+      },
+      "raum_soll_temp4": {
+        "name": "{prefix}Room setpoint temperature 4"
+      },
+      "raum_soll_temp5": {
+        "name": "{prefix}Room setpoint temperature 5"
+      },
+      "raum_temp": {
+        "name": "{prefix}Room temperature"
+      },
+      "raum_temp2": {
+        "name": "{prefix}Room temperature 2"
+      },
+      "raum_temp3": {
+        "name": "{prefix}Room temperature 3"
+      },
+      "raum_temp4": {
+        "name": "{prefix}Room temperature 4"
+      },
+      "raum_temp5": {
+        "name": "{prefix}Room temperature 5"
+      },
+      "rl_temp": {
+        "name": "{prefix}Return flow temperature"
+      },
+      "ruhemodus": {
+        "name": "{prefix}Silent mode",
+        "state": {
+          "hp_ruhemodus_0": "off",
+          "hp_ruhemodus_1": "80 %",
+          "hp_ruhemodus_2": "60 %",
+          "hp_ruhemodus_3": "40 %"
+        }
+      },
+      "schaltsp_e1": {
+        "name": "{prefix}Switching cycles E-heating 1"
+      },
+      "schaltsp_e2": {
+        "name": "{prefix}Switching cycles E-heating 2"
+      },
+      "sgr1": {
+        "name": "{prefix}SG-Ready 1"
+      },
+      "sgr2": {
+        "name": "{prefix}SG-Ready 2"
+      },
+      "soll_volumenstrom_heizen": {
+        "name": "{prefix}Setpoint volume flow Heating"
+      },
+      "soll_volumenstrom_kuehlen": {
+        "name": "{prefix}Setpoint volume flow Cooling"
+      },
+      "soll_volumenstrom_ww": {
+        "name": "{prefix}Setpoint volume flow Hot water"
+      },
+      "sollwert_pumpe_leistung_abtau": {
+        "name": "{prefix}Setpoint pump power defrost"
+      },
+      "sollwert_pumpe_leistung_heizen": {
+        "name": "{prefix}Setpoint pump power Heating"
+      },
+      "sollwert_pumpe_leistung_kuehlen": {
+        "name": "{prefix}Setpoint pump power Cooling"
+      },
+      "sollwert_pumpe_leitung_ww": {
+        "name": "{prefix}Setpoint pump power Hot water"
+      },
+      "status_2_wez": {
+        "name": "{prefix}Status 2nd heat source",
+        "state": {
+          "w2_status_aus": "off",
+          "w2_status_ein": "on"
+        }
+      },
+      "status_e1": {
+        "name": "{prefix}Status E-Heater 1",
+        "state": {
+          "w2_status_aus": "off",
+          "w2_status_ein": "on"
+        }
+      },
+      "status_e2": {
+        "name": "{prefix}Status E-Heater 2",
+        "state": {
+          "w2_status_aus": "off",
+          "w2_status_ein": "on"
+        }
+      },
+      "verdampfungs_temp": {
+        "name": "{prefix}Evaporation temperature"
+      },
+      "verdichter_ansaug_gas_temp": {
+        "name": "{prefix}Compressor suction gas temp"
+      },
+      "vl_praeziese_summenvorlauf_b7": {
+        "name": "{prefix}Feed temperature präzise(Summenvorlauf(B7))"
+      },
+      "vl_temp": {
+        "name": "{prefix}Feed temperature"
+      },
+      "w2_konf": {
+        "name": "{prefix}W2_Configuration",
+        "state": {
+          "w2_konf_0": "0",
+          "w2_konf_1": "1"
+        }
+      },
+      "waermeleistung": {
+        "name": "{prefix}Heating power"
+      },
+      "warnung": {
+        "name": "{prefix}Warning",
+        "state": {
+          "sys_fehler_1": "Refrigerant sensor expansion valve inlet (T1)",
+          "sys_fehler_10": "High pressure sensor (P2)",
+          "sys_fehler_101": "Heat pump is being operated outside the operating limits",
+          "sys_fehler_102": "Maximum defrost time exceeded",
+          "sys_fehler_103": "Communication refrigeration circuit faulty",
+          "sys_fehler_104": "discharge gas temperature too high",
+          "sys_fehler_105": "Current consumption from inverter too high",
+          "sys_fehler_106": "Current consumption too high",
+          "sys_fehler_107": "DC voltage on inverter too high",
+          "sys_fehler_108": "DC voltage on inverter too low",
+          "sys_fehler_109": "Heat pump is operated outside the permissible voltage range",
+          "sys_fehler_11": "Medium pressure sensor (P3)",
+          "sys_fehler_110": "Heat pump is being operated outside the permissible voltage range",
+          "sys_fehler_111": "High pressure switch has triggered",
+          "sys_fehler_112": "Inverter has overheated",
+          "sys_fehler_113": "Inverter has overheated",
+          "sys_fehler_114": "Position of compressor motor cannot be determined",
+          "sys_fehler_117": "DC voltage on inverter too low",
+          "sys_fehler_118": "Current between inverter and compressor is too high",
+          "sys_fehler_119": "Current consumption from compressor too high Timeout",
+          "sys_fehler_12": "Cooling expansion valve defective",
+          "sys_fehler_120": "Inverter temperature too high",
+          "sys_fehler_121": "Voltage on inverter too low",
+          "sys_fehler_122": "Modbus configuration error",
+          "sys_fehler_123": "No Modbus connection",
+          "sys_fehler_124": "discharge gas temperature too high",
+          "sys_fehler_127": "Inverter temperature too high",
+          "sys_fehler_128": "Inverter is overheated",
+          "sys_fehler_129": "Modbus communication faulty",
+          "sys_fehler_13": "No communication to the inverter",
+          "sys_fehler_130": "Modbus communication faulty",
+          "sys_fehler_133": "Electronics error",
+          "sys_fehler_135": "High pressure switch defective",
+          "sys_fehler_136": "Compressor does not match configuration",
+          "sys_fehler_137": "High pressure switch does not match the configuration",
+          "sys_fehler_14": "No communication with the outdoor unit",
+          "sys_fehler_140": "discharge gas temperature too low",
+          "sys_fehler_143": "Inverter temperature too low",
+          "sys_fehler_144": "Choke coil temperature too low",
+          "sys_fehler_15": "High pressure switch has triggered",
+          "sys_fehler_150": "Compressor current sensor phase U error",
+          "sys_fehler_151": "Compressor current sensor phase V error",
+          "sys_fehler_152": "Compressor current sensor phase W error voltage supply from input terminal",
+          "sys_fehler_153": "Current sensor error",
+          "sys_fehler_154": "Inverter temperature sensor error",
+          "sys_fehler_155": "Temperature sensor error",
+          "sys_fehler_156": "Compressed gas sensor (DT)",
+          "sys_fehler_157": "No communication to the cooling unit control board",
+          "sys_fehler_158": "EEPROM memory error",
+          "sys_fehler_159": "Current consumption too high",
+          "sys_fehler_16": "Inverter disabled because 10 errors have occurred in the last 10 hours",
+          "sys_fehler_160": "Heat pump is being operated outside the permissible voltage range",
+          "sys_fehler_161": "Heat pump is being operated outside the permissible voltage range",
+          "sys_fehler_162": "DC voltage on inverter too high",
+          "sys_fehler_163": "DC voltage on inverter too low",
+          "sys_fehler_164": "High pressure switch has triggered",
+          "sys_fehler_165": "Phase between input and compressor interrupted",
+          "sys_fehler_166": "Inverter overheated",
+          "sys_fehler_167": "Inverter overheated",
+          "sys_fehler_168": "Compressor configuration error",
+          "sys_fehler_169": "Compressor current consumption too high",
+          "sys_fehler_17": "EEPROM memory error",
+          "sys_fehler_170": "Compressor phase U overvoltage",
+          "sys_fehler_171": "Compressor phase V overvoltage",
+          "sys_fehler_172": "Compressor phase W overvoltage",
+          "sys_fehler_173": "Compressor phase failure",
+          "sys_fehler_174": "Compressor blocked",
+          "sys_fehler_175": "Compressor does not start",
+          "sys_fehler_176": "Irregular voltage supply from inverter",
+          "sys_fehler_177": "Compressor overloaded",
+          "sys_fehler_178": "Temperature at discharge gas sensor (DT) too high",
+          "sys_fehler_179": "Temperature at inverter",
+          "sys_fehler_18": "No Modbus communication between EC controller and refrigeration unit control board",
+          "sys_fehler_180": "Compressor blocked",
+          "sys_fehler_181": "Compressor blocked",
+          "sys_fehler_182": "Current consumption too high",
+          "sys_fehler_183": "Current consumption too high",
+          "sys_fehler_184": "Voltage too high",
+          "sys_fehler_19": "Heat pump switched off by inverter alarm",
+          "sys_fehler_2": "Air intake sensor (T2)",
+          "sys_fehler_20": "Compressor does not match the configuration",
+          "sys_fehler_21": "Low pressure fault",
+          "sys_fehler_22": "Insufficient superheat",
+          "sys_fehler_23": "excessive superheat",
+          "sys_fehler_24": "EVI too high overheating",
+          "sys_fehler_25": "Refrigerant quantity too low",
+          "sys_fehler_26": "High pressure fault",
+          "sys_fehler_27": "Condensation temperature too low",
+          "sys_fehler_28": "Condensation temperature too high",
+          "sys_fehler_29": "Evaporation temperature too low",
+          "sys_fehler_3": "Heat exchanger sensor AG outlet (T3)",
+          "sys_fehler_30": "Evaporation temperature too high",
+          "sys_fehler_32": "Heat pump not compatible",
+          "sys_fehler_33": "Controller EC has no connection to expansion module EM-HK",
+          "sys_fehler_4": "Compressor suction gas sensor (T4)",
+          "sys_fehler_40": "Volume flow too low",
+          "sys_fehler_41": "Spreizung LWT/Rücklauf negative / four-way valve does not switch back after defrosting; the system locks after 3 warnings)",
+          "sys_fehler_43": "Fan blocked",
+          "sys_fehler_44": "Fan speed too low",
+          "sys_fehler_47": "Communication controller EC to control board refrigeration unit faulty",
+          "sys_fehler_5": "EVI suction gas sensor (T5)",
+          "sys_fehler_50": "Outdoor sensor (B1) interrupted",
+          "sys_fehler_51": "Outdoor sensor (B1) short-circuited",
+          "sys_fehler_52": "Point sensor (B2) interrupted",
+          "sys_fehler_53": "Point sensor (B2) short-circuited",
+          "sys_fehler_54": "Hot water sensor (B3) interrupted",
+          "sys_fehler_55": "Hot water sensor (B3) short-circuited",
+          "sys_fehler_56": "Condenser flow sensor (B4) interrupted",
+          "sys_fehler_57": "Condenser flow sensor (B4) short-circuited",
+          "sys_fehler_58": "Flow sensor (B7) interrupted",
+          "sys_fehler_59": "Flow sensor (B7) short-circuited",
+          "sys_fehler_6": "Refrigerant sensor IG outlet (T6)",
+          "sys_fehler_60": "Return flow sensor (B9) interrupted",
+          "sys_fehler_61": "Return flow sensor (B9) short-circuited",
+          "sys_fehler_64": "Buffer sensor (B11) interrupted",
+          "sys_fehler_65": "Buffer sensor (B11) short-circuited",
+          "sys_fehler_65535": "no error",
+          "sys_fehler_66": "Regenerative mixer sensor (B2.1) interrupted",
+          "sys_fehler_67": "Regenerative mixer sensor (B2.1) short-circuited",
+          "sys_fehler_7": "Oil sump sensor (T7)",
+          "sys_fehler_70": "Second heating circuit flow sensor (B6.2) interrupted",
+          "sys_fehler_71": "Second heating circuit flow sensor (B6.2) short-circuited",
+          "sys_fehler_72": "Sensor (T1.2) interrupted",
+          "sys_fehler_73": "Sensor (T1.2) short-circuited",
+          "sys_fehler_74": "Sensor (T2.2) interrupted",
+          "sys_fehler_75": "Sensor (T2.2) short-circuited",
+          "sys_fehler_8": "Expansion valve EVI",
+          "sys_fehler_9": "Low pressure sensor (P1)",
+          "sys_fehler_90": "Analog input AE1 interrupted",
+          "sys_fehler_91": "Analog input AE1 short-circuited",
+          "sys_fehler_92": "Analog input AE2 interrupted",
+          "sys_fehler_93": "Analog input AE2 short-circuited",
+          "sys_fehler_94": "Analog input AE3 interrupted",
+          "sys_fehler_95": "Analog input AE3 short-circuited"
+        }
+      },
+      "weichen_temp": {
+        "name": "{prefix}Switch temperature"
+      },
+      "wp_betrieb": {
+        "name": "{prefix}Operation",
+        "state": {
+          "heatpump_operationmode_undefined": "Undefined",
+          "heatpump_operationmode_relaistest": "Relay test",
+          "heatpump_operationmode_evu": "EVU_SPERRE",
+          "heatpump_operationmode_sgtariff": "SG tariff",
+          "heatpump_operationmode_sgmax": "SG Maximum",
+          "heatpump_operationmode_tariffload": "Tariff load",
+          "heatpump_operationmode_elevatedoperation": "Increased operation",
+          "heatpump_operationmode_standbytime": "Standstill time",
+          "heatpump_operationmode_standby": "Standby mode",
+          "heatpump_operationmode_rinse": "Rinsing mode",
+          "heatpump_operationmode_frosprotection": "Frost protection",
+          "heatpump_operationmode_heating": "Heating mode",
+          "heatpump_operationmode_emergencystop": "Emergency stop",
+          "heatpump_operationmode_hotwater": "Hot water mode",
+          "heatpump_operationmode_legionellaprotection": "Legionella protection",
+          "heatpump_operationmode_switchheatingcooling": "Switchover HZ KU",
+          "heatpump_operationmode_cooling": "Cooling mode",
+          "heatpump_operationmode_passivecooling": "Passive cooling",
+          "heatpump_operationmode_summer": "Summer mode",
+          "heatpump_operationmode_swimmingpool": "Swimming pool",
+          "heatpump_operationmode_vacation": "Vacation",
+          "heatpump_operationmode_screedprogram": "Screed",
+          "heatpump_operationmode_locked": "Locked",
+          "heatpump_operationmode_diagnosis": "Diagnosis",
+          "heatpump_operationmode_lockedat": "Lock AT",
+          "hp_bheatpump_operationmode_lockedsummeretrieb_31": "Lock summer",
+          "heatpump_operationmode_lockedwinter": "Winter lock",
+          "heatpump_operationmode_applicationlimit": "Application limit",
+          "heatpump_operationmode_lockedcv": "HK lock",
+          "heatpump_operationmode_lowering": "lowering",
+          "heatpump_operationmode_manual": "Manual mode",
+          "heatpump_operationmode_oilrecirculation": "Oil return",
+          "heatpump_operationmode_manualheating": "Manual mode heating",
+          "heatpump_operationmode_manualcooling": "Manual mode cooling",
+          "heatpump_operationmode_manualdefrost": "Manual defrosting mode",
+          "heatpump_operationmode_defrost": "Defrost",
+          "heatpump_operationmode_manual2ndheatsource": "2nd heat source"
+        }
+      },
+      "wp_konf": {
+        "name": "{prefix}Configuration",
+        "state": {
+          "hp_conf_1": "Heating",
+          "hp_conf_2": "Heating, Cooling",
+          "hp_conf_3": "Heating, Cooling",
+          "hp_conf_4": "Heating, Hot water",
+          "hp_konf_0": "not configured"
+        }
+      },
+      "wp_stoermeldung": {
+        "name": "{prefix}Error message",
+        "state": {
+          "hp_stoerung": "error",
+          "hp_stoerungsfrei": "no error"
+        }
+      },
+      "tagesarbeitszahl_heute": {
+        "name": "{prefix}Daily performance factor today"
+      },
+      "spreizung": {
+        "name": "{prefix}Spread"
+      },
+      "jahresarbeitszahl": {
+        "name": "{prefix}Annual performance factor"
+      },
+      "tagesarbeitszahl_gestern": {
+        "name": "{prefix}Daily performance factor yesterday"
+      },
+      "monatsarbeitszahl": {
+        "name": "{prefix}Monthly performance factor"
+      },
+      "ww_energie_yesterday": {
+        "name": "{prefix}Hot water energy yesterday"
+      },
+      "ww_energie_heute": {
+        "name": "{prefix}Hot water energy heute"
+      },
+      "ww_energie_jahr": {
+        "name": "{prefix}Hot water energy year"
+      },
+      "ww_energie_monat": {
+        "name": "{prefix}Hot water energy month"
+      },
+      "ww_konf": {
+        "name": "{prefix}HW_Configuration",
+        "state": {
+          "ww_konf_aus": "off",
+          "ww_konf_pumpe": "Pump",
+          "ww_konf_umlenkventil": "Diverting valve"
+        }
+      },
+      "ww_soll_temp": {
+        "name": "{prefix}Hot water setpoint temperature"
+      },
+      "ww_temp": {
+        "name": "{prefix}Hot water temperature"
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "api_scan_interval": "Api scan interval (default = 300 sec)",
+          "language": "Language (default = en)",
+          "mode": "Mode(default = api)",
+          "scan_interval": "Web scraping interval (default = 1800 sec)"
+        }
+      }
+    }
+  },
+  "title": "Weishaupt Heat Pump"
 }


### PR DESCRIPTION
- Fixed some formal issues and typos.
  I used the tool configuration from home assistant core.
- Added `Path` import in `__init__.py` for better file handling.
  @OStrama Open: Why was this import commented out `# from pathlib import Path`? (see __init__.py line 248, 249, 258)
- Updated docstrings across multiple files for clarity and consistency.


Note: Spelling is a German & English mixture - not sure whether this can be changed (breaking)

Observations: 
- sensor name  "abtau_energie_gester" should be "abtau_energie_gestern"

