### PR TITLE
Fix pymodbus API call for pymodbus >=3.10.0 | HA 2025.09.0

### DIFF
--- a/custom_components/weishaupt_modbus/manifest.json
+++ b/custom_components/weishaupt_modbus/manifest.json
@@ -12,7 +12,7 @@
     "weishaupt_modbus"
   ],
   "requirements": [
-    "pymodbus>=3.9.2",
+    "pymodbus>=3.10.0",
     "aiofiles>=24.1.0",
     "beautifulsoup4>=4.13.3"
   ],

--- a/custom_components/weishaupt_modbus/manifest.json
+++ b/custom_components/weishaupt_modbus/manifest.json
@@ -12,7 +12,7 @@
     "weishaupt_modbus"
   ],
   "requirements": [
-    "pymodbus<=3.9.2",
+    "pymodbus>=3.9.2",
     "aiofiles>=24.1.0",
     "beautifulsoup4>=4.13.3"
   ],

--- a/custom_components/weishaupt_modbus/modbusobject.py
+++ b/custom_components/weishaupt_modbus/modbusobject.py
@@ -232,7 +232,7 @@ class ModbusObject:
                     case TYPES.SENSOR | TYPES.SENSOR_CALC:
                         # Sensor entities are read-only
                         mbr = await self._modbus_client.read_input_registers(
-                            self._modbus_item.address, slave=1
+                            self._modbus_item.address, device_id=1
                         )
                         return self.validate_modbus_answer(mbr)
                     case (
@@ -241,7 +241,7 @@ class ModbusObject:
                         | TYPES.NUMBER_RO
                     ):
                         mbr = await self._modbus_client.read_holding_registers(
-                            self._modbus_item.address, slave=1
+                            self._modbus_item.address, device_id=1
                         )
                         return self.validate_modbus_answer(mbr)
                     case _:


### PR DESCRIPTION
- Changed pymodbus requirement back to >=3.9.2
- Fixed API calls in modbusobject.py to match pymodbus API => 3.10.0