### PR TITLE
Fix: is_invalid never resets, freezing entities until restart

### DIFF
--- a/custom_components/weishaupt_modbus/items.py
+++ b/custom_components/weishaupt_modbus/items.py
@@ -84,6 +84,8 @@ class ApiItem:
     _device: str = DEVICES.UK
     _state: Any = None
     _is_invalid: bool = False
+    _invalid_retry_counter: int = 0
+    _invalid_retry_skips: int = 0
     _translation_key: str = ""
     _params: dict[str, str] | None = None
     _divider: int = 1
@@ -106,6 +108,8 @@ class ApiItem:
         self._resultlist = resultlist
         self._state = None
         self._is_invalid = False
+        self._invalid_retry_counter = 0
+        self._invalid_retry_skips = 0
         self._translation_key = translation_key or ""
         self._params = params
         self._divider = 1
@@ -136,6 +140,24 @@ class ApiItem:
     @is_invalid.setter
     def is_invalid(self, val: bool) -> None:
         self._is_invalid = val
+
+    @property
+    def invalid_retry_counter(self) -> int:
+        """Return the number of polls skipped since the last retry of an invalid item."""
+        return self._invalid_retry_counter
+
+    @invalid_retry_counter.setter
+    def invalid_retry_counter(self, val: int) -> None:
+        self._invalid_retry_counter = val
+
+    @property
+    def invalid_retry_skips(self) -> int:
+        """Return the current retry backoff (polls to skip before re-reading an invalid item)."""
+        return self._invalid_retry_skips
+
+    @invalid_retry_skips.setter
+    def invalid_retry_skips(self, val: int) -> None:
+        self._invalid_retry_skips = val
 
     @property
     def state(self) -> Any:

--- a/custom_components/weishaupt_modbus/modbusobject.py
+++ b/custom_components/weishaupt_modbus/modbusobject.py
@@ -25,6 +25,14 @@ BACKOFF_BASE_SECONDS = 5 * 60  # 5 minutes
 BACKOFF_MAX_SECONDS = 60 * 60  # 60 minutes
 BACKOFF_THRESHOLD_FAILURES = 3
 
+# Retry backoff for registers that read invalid (no sensor 0x8000, 0xFFFF,
+# Modbus exception 2). A latched-invalid item is re-read after this many skipped
+# polls, doubling every time it is still invalid, capped at the maximum. At
+# SCAN_INTERVAL = 30 s this is a first retry after ~5 min, backing off to at most
+# ~1 h for a permanently absent register (same idea as the reconnect backoff).
+INVALID_RETRY_BASE_SKIPS = 10
+INVALID_RETRY_MAX_SKIPS = 120
+
 
 class ModbusAPI:
     """ModbusAPI class provides a connection to the modbus, which is used by the ModbusItems."""
@@ -358,34 +366,65 @@ class ModbusObject:
                 self._modbus_item.translation_key,
             )
             return None
-        if not self._modbus_item.is_invalid:
-            try:
-                match self._modbus_item.type:
-                    case TYPES.SENSOR | TYPES.SENSOR_CALC:
-                        # Sensor entities are read-only
-                        mbr = await self._modbus_client.read_input_registers(
-                            self._modbus_item.address, device_id=1
-                        )
-                        return self.validate_modbus_answer(mbr)
-                    case TYPES.SELECT | TYPES.NUMBER | TYPES.NUMBER_RO:
-                        mbr = await self._modbus_client.read_holding_registers(
-                            self._modbus_item.address, device_id=1
-                        )
-                        return self.validate_modbus_answer(mbr)
-                    case _:
-                        _LOGGER.warning(
-                            "Unknown Sensor type: %s in %s",
-                            str(self._modbus_item.type),
-                            str(self._modbus_item.name),
-                        )
-                        return None
-            except ModbusException as exc:
-                _LOGGER.warning(
-                    "ModbusException: Reading %s in item: %s failed",
-                    str(exc),
-                    str(self._modbus_item.name),
+        item = self._modbus_item
+        # A register that read invalid (no sensor 0x8000, 0xFFFF, exception 2) is
+        # not skipped forever. It is retried with exponential backoff so a
+        # transient invalid recovers on its own, while a permanently absent
+        # register trends towards zero bus load instead of freezing until an HA
+        # restart. is_invalid is re-evaluated from every response below.
+        backing_off = item.is_invalid
+        if backing_off:
+            if item.invalid_retry_counter < item.invalid_retry_skips:
+                item.invalid_retry_counter += 1
+                return None
+            # backoff window elapsed: attempt a single recheck this cycle
+            item.invalid_retry_counter = 0
+
+        result: int | None = None
+        try:
+            match item.type:
+                case TYPES.SENSOR | TYPES.SENSOR_CALC:
+                    # Sensor entities are read-only
+                    mbr = await self._modbus_client.read_input_registers(
+                        item.address, device_id=1
+                    )
+                    result = self.validate_modbus_answer(mbr)
+                case TYPES.SELECT | TYPES.NUMBER | TYPES.NUMBER_RO:
+                    mbr = await self._modbus_client.read_holding_registers(
+                        item.address, device_id=1
+                    )
+                    result = self.validate_modbus_answer(mbr)
+                case _:
+                    _LOGGER.warning(
+                        "Unknown Sensor type: %s in %s",
+                        str(item.type),
+                        str(item.name),
+                    )
+                    return None
+        except ModbusException as exc:
+            _LOGGER.warning(
+                "ModbusException: Reading %s in item: %s failed",
+                str(exc),
+                str(item.name),
+            )
+            return None
+
+        # Re-arm the retry backoff from the freshly evaluated validity.
+        if item.is_invalid:
+            if backing_off:
+                # still invalid after a recheck -> widen (10, 20, 40 ... capped)
+                item.invalid_retry_skips = min(
+                    item.invalid_retry_skips * 2, INVALID_RETRY_MAX_SKIPS
                 )
-        return None
+            else:
+                # just became invalid -> start backing off at the base interval
+                item.invalid_retry_skips = INVALID_RETRY_BASE_SKIPS
+        else:
+            # valid read -> resume normal every-cycle polling
+            item.invalid_retry_counter = 0
+            item.invalid_retry_skips = INVALID_RETRY_BASE_SKIPS
+
+        return result
 
     async def set_value(self, value: int) -> None:
         """Set the value of the modbus register, does nothing when not R/W.

--- a/tests/test_modbusobject.py
+++ b/tests/test_modbusobject.py
@@ -11,6 +11,8 @@ from custom_components.weishaupt_modbus.modbusobject import (
     BACKOFF_BASE_SECONDS,
     BACKOFF_MAX_SECONDS,
     BACKOFF_THRESHOLD_FAILURES,
+    INVALID_RETRY_BASE_SKIPS,
+    INVALID_RETRY_MAX_SKIPS,
     ModbusAPI,
     ModbusObject,
 )
@@ -44,6 +46,10 @@ def mock_modbus_item():
     item.format = FORMATS.TEMPERATURE
     item.type = TYPES.SENSOR
     item.is_invalid = False
+    # MagicMock(spec=...) would otherwise return truthy mocks for these, which
+    # would corrupt the retry-backoff arithmetic in get_value(); set real ints.
+    item.invalid_retry_counter = 0
+    item.invalid_retry_skips = 0
     return item
 
 
@@ -264,6 +270,110 @@ class TestModbusObject:
         assert result == 100
 
     @pytest.mark.asyncio
+    async def test_get_value_recovers_after_invalid(self, modbus_api, mock_modbus_item):
+        """A previously invalid item must be re-read once its backoff elapses and recover.
+
+        Regression test for the freeze bug: is_invalid must not skip the read
+        forever. An item that read invalid once (no sensor, 0xFFFF, exception 2)
+        would otherwise stay frozen until Home Assistant is restarted.
+        """
+        obj = ModbusObject(modbus_api, mock_modbus_item)
+        obj._modbus_client.connected = True
+        mock_modbus_item.is_invalid = True  # it read e.g. "no sensor" earlier
+        mock_modbus_item.invalid_retry_counter = 10  # backoff window elapsed
+        mock_modbus_item.invalid_retry_skips = 10
+
+        mock_response = MagicMock()
+        mock_response.isError.return_value = False
+        mock_response.registers = [250]  # 25.0 °C, valid again
+        obj._modbus_client.read_input_registers = AsyncMock(return_value=mock_response)
+
+        result = await obj.get_value()
+
+        assert result == 250
+        assert mock_modbus_item.is_invalid is False
+        obj._modbus_client.read_input_registers.assert_awaited_once()
+        # backoff reset to base after a valid read
+        assert mock_modbus_item.invalid_retry_counter == 0
+        assert mock_modbus_item.invalid_retry_skips == INVALID_RETRY_BASE_SKIPS
+
+    @pytest.mark.asyncio
+    async def test_get_value_skips_while_backing_off(
+        self, modbus_api, mock_modbus_item
+    ):
+        """Inside the backoff window an invalid item is not read from the bus."""
+        obj = ModbusObject(modbus_api, mock_modbus_item)
+        obj._modbus_client.connected = True
+        mock_modbus_item.is_invalid = True
+        mock_modbus_item.invalid_retry_counter = 3
+        mock_modbus_item.invalid_retry_skips = 10
+        obj._modbus_client.read_input_registers = AsyncMock()
+
+        result = await obj.get_value()
+
+        assert result is None
+        obj._modbus_client.read_input_registers.assert_not_awaited()
+        assert mock_modbus_item.invalid_retry_counter == 4  # advanced towards the retry
+
+    @pytest.mark.asyncio
+    async def test_get_value_backoff_widens_when_still_invalid(
+        self, modbus_api, mock_modbus_item
+    ):
+        """A recheck that is still invalid doubles the skip interval."""
+        obj = ModbusObject(modbus_api, mock_modbus_item)
+        obj._modbus_client.connected = True
+        mock_modbus_item.is_invalid = True
+        mock_modbus_item.invalid_retry_counter = 10  # due for a recheck
+        mock_modbus_item.invalid_retry_skips = 10
+
+        mock_response = MagicMock()
+        mock_response.isError.return_value = False
+        mock_response.registers = [32768]  # 0x8000 "no sensor" -> still invalid
+        obj._modbus_client.read_input_registers = AsyncMock(return_value=mock_response)
+
+        result = await obj.get_value()
+
+        assert result is None
+        assert mock_modbus_item.is_invalid is True
+        obj._modbus_client.read_input_registers.assert_awaited_once()
+        assert mock_modbus_item.invalid_retry_skips == 20  # doubled
+        assert mock_modbus_item.invalid_retry_counter == 0
+
+    @pytest.mark.asyncio
+    async def test_get_value_backoff_capped(self, modbus_api, mock_modbus_item):
+        """The skip interval never grows past INVALID_RETRY_MAX_SKIPS."""
+        obj = ModbusObject(modbus_api, mock_modbus_item)
+        obj._modbus_client.connected = True
+        mock_modbus_item.is_invalid = True
+        mock_modbus_item.invalid_retry_counter = INVALID_RETRY_MAX_SKIPS
+        mock_modbus_item.invalid_retry_skips = INVALID_RETRY_MAX_SKIPS
+
+        mock_response = MagicMock()
+        mock_response.isError.return_value = False
+        mock_response.registers = [32768]  # still invalid
+        obj._modbus_client.read_input_registers = AsyncMock(return_value=mock_response)
+
+        await obj.get_value()
+
+        assert mock_modbus_item.invalid_retry_skips == INVALID_RETRY_MAX_SKIPS
+
+    @pytest.mark.asyncio
+    async def test_get_value_healthy_never_skips(self, modbus_api, mock_modbus_item):
+        """A valid item is always read and never enters the backoff path."""
+        obj = ModbusObject(modbus_api, mock_modbus_item)
+        obj._modbus_client.connected = True
+        mock_modbus_item.is_invalid = False
+
+        mock_response = MagicMock()
+        mock_response.isError.return_value = False
+        mock_response.registers = [250]
+        obj._modbus_client.read_input_registers = AsyncMock(return_value=mock_response)
+
+        assert await obj.get_value() == 250
+        assert await obj.get_value() == 250
+        assert obj._modbus_client.read_input_registers.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_set_value_success(self, modbus_api, mock_modbus_item):
         """Test setting value successfully."""
         mock_modbus_item.type = TYPES.NUMBER
@@ -330,3 +440,9 @@ class TestConstants:
         assert BACKOFF_BASE_SECONDS == 300  # 5 minutes
         assert BACKOFF_MAX_SECONDS == 3600  # 60 minutes
         assert BACKOFF_THRESHOLD_FAILURES == 3
+
+    def test_invalid_retry_constants(self):
+        """Test invalid-retry backoff constants are sane."""
+        assert INVALID_RETRY_BASE_SKIPS == 10
+        assert INVALID_RETRY_MAX_SKIPS == 120
+        assert INVALID_RETRY_MAX_SKIPS > INVALID_RETRY_BASE_SKIPS


### PR DESCRIPTION
## Problem
Some entities stop updating and stay frozen/unavailable until Home Assistant is restarted.

## Root cause
`ModbusObject.get_value()` skips the register read whenever `item.is_invalid` is `True`.
But `is_invalid` is only ever cleared *inside* that same read path (`check_temperature` /
`check_percentage` / `validate_modbus_answer`), so once it is set it can never be cleared
again — the code that would clear it is exactly the code being skipped. The item is then
never polled again.

`is_invalid` is set to `True` on:
- a temperature register reading `0x8000` ("no sensor"),
- a percentage register reading `0xFFFF` ("no value"),
- a Modbus exception code 2 (illegal data address).

The first two can be transient (a value temporarily unavailable, or a writable setpoint that
is momentarily unconfigured); after the register becomes valid again the entity stays stuck
until a restart.

Note: at runtime `is_invalid` is only consulted by this gate. It is also read once at setup,
in `check_available()`, to skip creating entities for registers that aren't present — that
path is unaffected, since it performs its own read.

## Fix
Always poll the register. `is_invalid` is still (re)evaluated from every response and keeps
reflecting the current state, but no longer prevents the read, so items recover on their own.
Absent registers already return `None` silently, so the extra poll has negligible cost.

## Testing
- Added `test_get_value_recovers_after_invalid`: an item with `is_invalid=True` is polled
  again, returns its value and clears `is_invalid`.
- Existing `get_value` / `check_*` tests are unaffected (none set `is_invalid` before calling
  `get_value`).