### PR TITLE
Isolate WebIF sensor setup so it cannot take down Modbus sensors

### DIFF
--- a/custom_components/weishaupt_modbus/sensor.py
+++ b/custom_components/weishaupt_modbus/sensor.py
@@ -20,34 +20,41 @@ async def async_setup_entry(
 ) -> None:
     """Set up the sensor platform."""
 
-    # start with an empty list of entries
-    entries: list[Any] = []
-
     # we create one communicator per integration only for better performance and to allow dynamic parameters
     coordinator = config_entry.runtime_data.coordinator
     webif_coordinator = config_entry.runtime_data.webif_coordinator
 
+    # Add the Modbus sensors on their own, before and independently of the
+    # optional WebIF sensors, so that a problem while setting up the WebIF
+    # sensors can never prevent the Modbus sensors from being registered
+    # (issue #172).
     if coordinator is not None:
-        entries = await build_entity_list(
-            entries=entries,
+        modbus_entries: list[Any] = await build_entity_list(
+            entries=[],
             config_entry=config_entry,
             api_items=coordinator.modbus_items,
             item_types=(TYPES.NUMBER_RO, TYPES.SENSOR_CALC, TYPES.SENSOR),
             coordinator=coordinator,
         )
-
-    if webif_coordinator is not None:
-        await build_webif_entity_list(
-            entries=entries,
-            config_entry=config_entry,
-            api_items=webif_coordinator.api_items,
-            item_type=(TYPES.SENSOR),
-            coordinator=webif_coordinator,
+        async_add_entities(
+            modbus_entries,
+            update_before_add=False,
         )
 
-    # entries.extend(webifentries)
-
-    async_add_entities(
-        entries,
-        update_before_add=False,
-    )
+    if webif_coordinator is not None:
+        try:
+            webif_entries: list[Any] = await build_webif_entity_list(
+                entries=[],
+                config_entry=config_entry,
+                api_items=webif_coordinator.api_items,
+                item_type=(TYPES.SENSOR),
+                coordinator=webif_coordinator,
+            )
+            async_add_entities(
+                webif_entries,
+                update_before_add=False,
+            )
+        except Exception:
+            _LOGGER.exception(
+                "Setting up WebIF sensors failed; Modbus sensors are not affected"
+            )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,117 @@
+"""Unit tests for the sensor platform setup."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.weishaupt_modbus import sensor
+
+
+def make_config_entry(with_webif: bool) -> MagicMock:
+    """Create a mock config entry with coordinator runtime data."""
+    config_entry = MagicMock()
+    config_entry.runtime_data.coordinator = MagicMock()
+    config_entry.runtime_data.coordinator.modbus_items = []
+    if with_webif:
+        config_entry.runtime_data.webif_coordinator = MagicMock()
+        config_entry.runtime_data.webif_coordinator.api_items = []
+    else:
+        config_entry.runtime_data.webif_coordinator = None
+    return config_entry
+
+
+def added_entities(async_add_entities: MagicMock) -> list:
+    """Collect all entities passed to async_add_entities across all calls."""
+    return [
+        entity for call in async_add_entities.call_args_list for entity in call.args[0]
+    ]
+
+
+class TestSensorSetup:
+    """Test the sensor platform setup."""
+
+    @pytest.mark.asyncio
+    async def test_modbus_sensors_added_when_webif_setup_fails(self):
+        """Modbus sensors must be added even if the WebIF setup raises.
+
+        Regression test for issue #172: the sensor platform used to build
+        Modbus and WebIF entities into one list and call async_add_entities
+        only once at the very end, so any error in the WebIF part prevented
+        the already built Modbus sensors from being registered.
+        """
+        config_entry = make_config_entry(with_webif=True)
+        async_add_entities = MagicMock()
+        modbus_entities = [MagicMock(), MagicMock()]
+
+        with (
+            patch.object(
+                sensor,
+                "build_entity_list",
+                AsyncMock(return_value=modbus_entities),
+            ),
+            patch.object(
+                sensor,
+                "build_webif_entity_list",
+                AsyncMock(side_effect=RuntimeError("WebIF broken")),
+            ),
+        ):
+            await sensor.async_setup_entry(
+                MagicMock(), config_entry, async_add_entities
+            )
+
+        assert added_entities(async_add_entities) == modbus_entities
+
+    @pytest.mark.asyncio
+    async def test_all_sensors_added_when_webif_works(self):
+        """Modbus and WebIF sensors are all added when both setups succeed."""
+        config_entry = make_config_entry(with_webif=True)
+        async_add_entities = MagicMock()
+        modbus_entities = [MagicMock(), MagicMock()]
+        webif_entities = [MagicMock()]
+        expected = [*modbus_entities, *webif_entities]
+
+        async def fake_build_webif_entity_list(entries, **kwargs):
+            # Mirror the real contract: extend the passed list and return it.
+            entries.extend(webif_entities)
+            return entries
+
+        with (
+            patch.object(
+                sensor,
+                "build_entity_list",
+                AsyncMock(return_value=modbus_entities),
+            ),
+            patch.object(
+                sensor,
+                "build_webif_entity_list",
+                AsyncMock(side_effect=fake_build_webif_entity_list),
+            ),
+        ):
+            await sensor.async_setup_entry(
+                MagicMock(), config_entry, async_add_entities
+            )
+
+        assert added_entities(async_add_entities) == expected
+
+    @pytest.mark.asyncio
+    async def test_webif_skipped_without_webif_coordinator(self):
+        """Only Modbus sensors are added when no WebIF coordinator exists."""
+        config_entry = make_config_entry(with_webif=False)
+        async_add_entities = MagicMock()
+        modbus_entities = [MagicMock()]
+        webif_mock = AsyncMock()
+
+        with (
+            patch.object(
+                sensor,
+                "build_entity_list",
+                AsyncMock(return_value=modbus_entities),
+            ),
+            patch.object(sensor, "build_webif_entity_list", webif_mock),
+        ):
+            await sensor.async_setup_entry(
+                MagicMock(), config_entry, async_add_entities
+            )
+
+        assert added_entities(async_add_entities) == modbus_entities
+        webif_mock.assert_not_awaited()


### PR DESCRIPTION
## Problem
As reported in #172: when the WebIF part of the integration breaks, all Modbus
*sensors* become unavailable, while number/select entities (holding registers)
keep updating. Reloading the integration does not help, and the registers are
still readable with other Modbus clients.

## Cause (structural)
The sensor platform builds Modbus **and** WebIF entities into a single list and
calls `async_add_entities` only once at the very end. Any error raised while
setting up the optional WebIF sensors therefore prevents the already built
Modbus sensors from being registered — the sensor platform fails as a whole.
number/select live in their own platforms, which is why holding registers keep
working. This exactly matches the failure pattern in #172.

## Fix
Register the Modbus sensors on their own, immediately after building them, and
guard the optional WebIF setup so a WebIF problem can only ever cost the WebIF
sensors (logged with a traceback for diagnosis). Modbus-side errors still fail
loudly as before — only the optional WebIF part is isolated.

I could not reproduce the exact trigger of #172 without the reporter's logs, so
this is framed as hardening: relates to #172, and should at least keep Modbus
sensors alive in that scenario.

## Testing
New `tests/test_sensor.py`:
- Modbus sensors survive a WebIF setup failure (fails on current main, passes with this PR)
- everything is added when both parts work (passes on both — behaviour preserved)
- WebIF is skipped without a WebIF coordinator (passes on both)

`ruff format --check`, `ruff check` and `mypy` on `custom_components/` are
clean/identical to main. Note: recent ruff versions flag one pre-existing I001
(import order) in `coordinator.py` on main — unrelated to this change, happy to
fix separately.