### PR TITLE
Fix WebIF numeric sensors crashing on non-numeric values (issue #159)

### DIFF
--- a/custom_components/weishaupt_modbus/entities.py
+++ b/custom_components/weishaupt_modbus/entities.py
@@ -492,9 +492,9 @@ class MyWebifSensorEntity(CoordinatorEntity, SensorEntity, MyEntity):
 
         if self._api_item.format == FORMATS.TEXT:
             self._attr_suggested_display_precision = None
-        # WebItems carry no params, so the unit/device_class block in
-        # MyEntity.__init__ is skipped and WebItem.get_value() strips the unit
-        # text ("26.0 °C" -> "26.0"). Restore unit + device class by format.
+        # WebItem.get_value() strips the unit text ("26.0 °C" -> "26.0"), so set
+        # unit + device class explicitly for the well-known scalar formats. Items
+        # that carry params get their device_class from MyEntity.__init__ as well.
         elif self._api_item.format == FORMATS.TEMPERATURE:
             self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
             self._attr_device_class = SensorDeviceClass.TEMPERATURE
@@ -513,15 +513,29 @@ class MyWebifSensorEntity(CoordinatorEntity, SensorEntity, MyEntity):
                 raw = self._api_item.get_value(
                     self.coordinator.data[self._api_item.name]
                 )
-                # get_value() returns the numeric part as a string; coerce to
-                # float for numeric formats so the temperature/percentage
-                # device class accepts the state instead of warning.
+                # get_value() returns a scraped string. Any sensor that carries a
+                # numeric device_class / state_class must expose a numeric (or None)
+                # native value, otherwise Home Assistant crashes converting a value
+                # like "Aus" via int()/float() (issue #159). Coerce for every numeric
+                # sensor, not just TEMPERATURE/PERCENTAGE. A non-numeric reading falls
+                # back to the item's "non_numeric_value" param (None by default, e.g.
+                # 0 for power sensors that report "off" as text in various languages).
                 value: float | str | None = raw
-                if self._api_item.format in (FORMATS.TEMPERATURE, FORMATS.PERCENTAGE):
+                if (
+                    self._attr_device_class is not None
+                    or self._attr_state_class is not None
+                ):
                     try:
-                        value = float(raw)
-                    except (TypeError, ValueError) as _err:
-                        value = None
+                        value = None if raw is None else float(raw)
+                    except ValueError:
+                        fallback = self._api_item.params.get("non_numeric_value")
+                        _LOGGER.debug(
+                            "WebIF sensor %s: non-numeric value %r, using %r",
+                            self._api_item.name,
+                            raw,
+                            fallback,
+                        )
+                        value = fallback
                 self._attr_native_value = value
                 self.async_write_ha_state()
             else:

--- a/custom_components/weishaupt_modbus/hpconst.py
+++ b/custom_components/weishaupt_modbus/hpconst.py
@@ -1212,6 +1212,10 @@ PARAMS_POWER: dict = {
     "precision": 0,
     "unit": UnitOfPower.WATT,
     "stateclass": SensorStateClass.MEASUREMENT,
+    # The web interface reports a switched-off pump as a localized text ("Aus",
+    # "Uit", "Off", ...) instead of a number. For a power reading that means 0 W,
+    # so fall back to 0 (language-independent) instead of "unknown".
+    "non_numeric_value": 0,
 }
 
 PARAMS_PRESSURE: dict = {

--- a/custom_components/weishaupt_modbus/items.py
+++ b/custom_components/weishaupt_modbus/items.py
@@ -286,11 +286,14 @@ class WebItem(ApiItem):
         """Set webif_group."""
         self._webif_group = val
 
-    def get_value(self, val: str) -> str:
+    def get_value(self, val: str | None) -> str | None:
         """Get the value based on the format."""
+        if val is None:
+            return None
         if self._format in [
             FORMATS.TEMPERATURE,
             FORMATS.PERCENTAGE,
+            FORMATS.NUMBER,
         ]:
             return val.split(" ", maxsplit=1)[0]
         return val

--- a/tests/test_webif_sensor.py
+++ b/tests/test_webif_sensor.py
@@ -1,0 +1,124 @@
+"""Unit tests for WebIF sensor value handling (issue #159)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.weishaupt_modbus import entities
+from custom_components.weishaupt_modbus.const import DEVICES, FORMATS, TYPES
+from custom_components.weishaupt_modbus.items import WebItem
+
+
+def make_webitem(
+    fmt: str, name: str = "Soll Leistung", params: dict | None = None
+) -> WebItem:
+    """Create a WebItem with the given format and optional params."""
+    return WebItem(
+        name=name,
+        mformat=fmt,
+        mtype=TYPES.SENSOR,
+        device=DEVICES.WIW,
+        webif_group="WIW",
+        translation_key="webif_test",
+        params=params,
+    )
+
+
+class TestWebItemGetValue:
+    """WebItem.get_value must strip units for numeric formats and tolerate None."""
+
+    def test_number_strips_unit(self):
+        """A NUMBER value keeps only the numeric part ('1234 kWh' -> '1234')."""
+        assert make_webitem(FORMATS.NUMBER).get_value("1234 kWh") == "1234"
+
+    def test_number_non_numeric_kept(self):
+        """A non-numeric NUMBER value is returned unchanged."""
+        assert make_webitem(FORMATS.NUMBER).get_value("Aus") == "Aus"
+
+    def test_temperature_strips_unit(self):
+        """A TEMPERATURE value keeps only the numeric part."""
+        assert make_webitem(FORMATS.TEMPERATURE).get_value("26.0 °C") == "26.0"
+
+    def test_text_kept_unchanged(self):
+        """A TEXT value is returned unchanged."""
+        assert make_webitem(FORMATS.TEXT).get_value("Betrieb aktiv") == "Betrieb aktiv"
+
+    def test_none_is_tolerated(self):
+        """A None value must not raise AttributeError on None.split(...)."""
+        assert make_webitem(FORMATS.TEMPERATURE).get_value(None) is None
+        assert make_webitem(FORMATS.NUMBER).get_value(None) is None
+
+
+class TestWebifSensorCoercion:
+    """MyWebifSensorEntity must never expose a non-numeric string on a numeric sensor.
+
+    Regression test for issue #159: a numeric WebIF sensor (e.g. "Soll Leistung",
+    FORMATS.NUMBER + power device_class) received the scraped string "Aus", which
+    Home Assistant then tried to int()/float() -> ValueError, crashing the
+    coordinator listener.
+    """
+
+    POWER_PARAMS = {"non_numeric_value": 0}
+
+    @staticmethod
+    def _run(fmt, device_class, state_class, value, params=None):
+        """Drive _handle_coordinator_update on a bare entity and return native_value."""
+        ent = entities.MyWebifSensorEntity.__new__(entities.MyWebifSensorEntity)
+        item = make_webitem(fmt, params=params)
+        ent._api_item = item
+        ent._attr_device_class = device_class
+        ent._attr_state_class = state_class
+        ent._attr_native_value = None
+        ent.coordinator = MagicMock()
+        ent.coordinator.data = {item.name: value}
+        ent.async_write_ha_state = MagicMock()
+
+        ent._handle_coordinator_update()
+
+        # The state was written exactly once.
+        ent.async_write_ha_state.assert_called_once()
+        return ent._attr_native_value
+
+    def test_non_numeric_on_numeric_sensor_becomes_none(self):
+        """Default: NUMBER + numeric device_class + 'Aus' -> None (no crash)."""
+        assert self._run(FORMATS.NUMBER, "power", None, "Aus") is None
+
+    def test_numeric_string_with_unit_is_parsed(self):
+        """A power/energy value like '1234 kWh' stays usable, not None."""
+        assert self._run(FORMATS.NUMBER, "power", None, "1234 kWh") == 1234.0
+
+    def test_plain_number_is_parsed(self):
+        """A plain numeric string is coerced to float."""
+        assert self._run(FORMATS.NUMBER, "power", None, "42.5") == 42.5
+
+    def test_state_class_only_also_coerces(self):
+        """A sensor with only a state_class (no device_class) is also coerced."""
+        assert self._run(FORMATS.NUMBER, None, "measurement", "Aus") is None
+
+    def test_non_numeric_sensor_keeps_text(self):
+        """A sensor without device_class/state_class keeps its string value."""
+        assert self._run(FORMATS.TEXT, None, None, "Betrieb aktiv") == "Betrieb aktiv"
+
+    def test_power_off_falls_back_to_zero(self):
+        """A power sensor with non_numeric_value=0 reports 0 W when switched off."""
+        assert self._run(FORMATS.NUMBER, "power", None, "Aus", self.POWER_PARAMS) == 0
+
+    @pytest.mark.parametrize("off_text", ["Aus", "Uit", "Off", "Arrêt", "---", ""])
+    def test_power_off_is_language_independent(self, off_text):
+        """The 0 fallback triggers on any non-numeric text, not just German 'Aus'."""
+        assert (
+            self._run(FORMATS.NUMBER, "power", None, off_text, self.POWER_PARAMS) == 0
+        )
+
+    def test_power_valid_value_still_parsed(self):
+        """A real power reading is still parsed, the fallback only applies on failure."""
+        assert (
+            self._run(FORMATS.NUMBER, "power", None, "1234 W", self.POWER_PARAMS)
+            == 1234.0
+        )
+
+    @pytest.mark.parametrize("value", ["Aus", "Ein", "---", "", "1234 kWh", "42.5"])
+    def test_numeric_sensor_value_is_never_a_non_numeric_string(self, value):
+        """Invariant that prevents the HA crash: native value is never a bad string."""
+        result = self._run(FORMATS.NUMBER, "power", None, value)
+        assert result is None or isinstance(result, (int, float))


### PR DESCRIPTION
## Problem
A WebIF sensor with a numeric device_class/state_class can receive a non-numeric
scraped value. Home Assistant then tries int()/float() on it and raises ValueError,
crashing the coordinator listener on every poll. Reported in #159: 
`could not convert string to float: 'Aus'` on the "Soll Leistung" power sensor
(FORMATS.NUMBER + power device_class).

## Cause
The existing coercion only ran for FORMATS.TEMPERATURE and FORMATS.PERCENTAGE.
NUMBER items (~25 energy/power/pressure/... sensors that also get a numeric
device_class from their params) fell through and wrote the raw string as native
value. The guard predates the report, so this is a coverage gap, not a regression.

## Fix
- `entities.py`: coerce for any sensor with a numeric device_class/state_class,
  not just two hard-coded formats. A non-numeric reading falls back to the item's
  `non_numeric_value` param (None by default) and is logged at debug level.
- `items.py`: `WebItem.get_value()` also strips the unit for NUMBER ("1234 kWh" ->
  "1234") and tolerates None (no AttributeError on None.split()).
- `hpconst.py`: the two power sensors report a switched-off pump as localized text
  ("Aus"/"Uit"/"Off"/...), which for a power reading means 0 W. `PARAMS_POWER` gets
  `"non_numeric_value": 0` so they fall back to 0 instead of "unknown". This is
  language-independent (it triggers on float() failing, not on matching a word).
- Fix a stale comment claiming WebItems carry no params.

Only WebIF items with a numeric device_class/state_class are affected; TEXT/STATUS
items carry no params, so their string values are untouched.

## Testing
`tests/test_webif_sensor.py` covers get_value, the coercion, the exact reported
sensor shape (NUMBER + power + "Aus"), and the language-independent 0 fallback.
The regression tests fail on current main and pass with this PR. `ruff format/check`
and `mypy` are unchanged vs main.

Relates to #159.